### PR TITLE
Render VI icons server-side from text lines

### DIFF
--- a/.claude/agents/labview-vi-editor.md
+++ b/.claude/agents/labview-vi-editor.md
@@ -96,6 +96,16 @@ So when the VI has one, validate the **untouched** export before promising anyth
   pane, names every breach and gives you the corrected assignment. Do not reason from a remembered
   map: `error in` is `conIdx 8` on the 12-terminal 4815 pane and `11` on the 16-terminal 4833 one, a
   generated VI has been measured as either, and a regeneration can move the VI from one to the other.
+
+  Two things that make a regeneration land on the wrong pane. First, **a full regeneration gets the
+  station's default pane, not the one the VI had** — that default is `DefaultConPane` in the
+  `LabVIEW.ini` beside `LabVIEW.exe`, it **overrides everything**, and `lvai_connector_pane` with
+  **no argument** reads it for you; if the key is absent, LabVIEW's factory default **4815** applies.
+  Read that file, quote it, never write to it. Second, **copy the whole style-guide block the tool
+  prints, not four numbers** — it gives `first input`, **`more inputs`**, `error in`, `first output`,
+  **`more outputs`**, `error out`, and the two `more` entries are the ones that get dropped.
+  **Consecutive `conIdx` is not the left edge**: on 4833 that edge is `0, 5, 7, 9`, so a second input
+  written as `1` lands in a middle column. That exact slip has shipped three times.
   That is what makes the check part of the edit rather than optional. Preserving an existing pane is the default — but a pane that
   breaks the guide is a defect worth naming in the report and correcting, since `conIdx` is one
   attribute per terminal and costs nothing to change. Detail in `lvai_aixml_reference` §2, "The
@@ -339,26 +349,20 @@ was the old workaround and cost about eight minutes of hand-built harness per VI
 
 `lvai_set_vi_icon` with `viPath` and `iconImagePath` = `icon_before.png`.
 
-If Phase 4 found no real icon, make one instead — 32x32 PNG, which is the only size and format
-measured:
+If Phase 4 found no real icon, have the tool draw one instead — **one call, no PowerShell**:
 
-```powershell
-Add-Type -AssemblyName System.Drawing
-$bmp = New-Object System.Drawing.Bitmap 32,32
-$g = [System.Drawing.Graphics]::FromImage($bmp)
-$g.TextRenderingHint = 'SingleBitPerPixelGridFit'   # crisp at 32 px; antialiasing turns to mud
-$g.Clear([System.Drawing.Color]::White)
-$g.FillRectangle((New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(0,90,156))), 0,0,32,9)
-$g.DrawRectangle([System.Drawing.Pens]::Black, 0,0,31,31)
-$f = New-Object System.Drawing.Font 'Segoe UI',5.5,([System.Drawing.FontStyle]::Bold)
-$g.DrawString('FILE',$f,[System.Drawing.Brushes]::White,0,-1)
-$g.DrawString('SORT',$f,[System.Drawing.Brushes]::Black,0,12)
-$g.Dispose()
-$bmp.Save('<abs>\icon.png',[System.Drawing.Imaging.ImageFormat]::Png)
-$bmp.Dispose()
+```
+lvai_set_vi_icon  viPath=<abs>  line1="FILE"  line2="SORT"
 ```
 
-Four to five characters per line is the ceiling; abbreviate rather than shrink the font.
+`line1` becomes a coloured banner, `line2` and `line3` sit under it, and the tool renders the 32x32
+PNG itself. Optional `bannerColor`, `backgroundColor`, `borderColor` as `RRGGBB`; text colour is
+picked for contrast. **Five characters per line is the ceiling** — abbreviate rather than spill;
+longer lines are cut and reported in `warnings`. Drawable: `A-Z 0-9 space - . / : + #`.
+
+A `PowerShell` + `System.Drawing` recipe used to stand here. It was measured at **12.5 s** of a
+generation session, plus a whole extra tool call, against 0 ms now. Reaching for `System.Drawing`
+means you are reading a stale copy of this file.
 
 Judge the result by the `verified` field and by looking at the read-back PNG — **not** by
 `errorCode`, which is 91 on success. If you regenerate again afterwards, the icon is gone again:

--- a/.claude/agents/labview-vi-generator.md
+++ b/.claude/agents/labview-vi-generator.md
@@ -85,23 +85,42 @@ it an icon.
   depends on the pane pattern, so ask `lvai_connector_pane` and do not reason about it:**
 
   1. **Before** you write any `conIdx`, call `lvai_connector_pane` with **no argument**. LabVIEW gives
-     every new VI the station's default pane (`DefaultConPane` in `LabVIEW.ini`), so the tool knows
-     which pattern you are about to get and prints the four numbers to write: first input, `error in`,
-     first output, `error out`.
-  2. Author the AIXML with exactly those numbers.
-  3. After generating, call it again with `viPath`. That confirms the pane you actually got and checks
-     every terminal against the style guide.
+     every new VI the station's default pane, read from **`DefaultConPane` in the `LabVIEW.ini` beside
+     `LabVIEW.exe`**, and that key **overrides everything** — never assume a pattern when the file can
+     be read. If the key is absent, LabVIEW's factory default **4815** applies. That file is read-only
+     to us: read it, quote it, never write to it.
+  2. **Copy the WHOLE style-guide block the tool prints, not four numbers.** It gives six entries —
+     `first input`, **`more inputs`**, `error in`, `first output`, **`more outputs`**, `error out`.
+     The two in bold are the ones that get dropped, and dropping them is the actual bug below.
+  3. Author the AIXML with exactly those numbers.
+  4. After generating, call it again with `viPath`. That confirms the pane you actually got and checks
+     every terminal against the style guide. Read-only, about 1 s per call.
 
-  How different two patterns really are, so neither step is skipped: `error in` belongs on `conIdx 8`
-  on pattern 4815 and on `11` on 4833, and `conIdx 0` is bottom-**right** on 4815 but top-**left** on
-  4833. Read-only, about 1 s per call.
+  **Consecutive `conIdx` is NOT the left edge.** This is the trap, and it has now shipped three
+  times in `DaqReadAndTDMS.vi`: the first input went correctly to `conIdx 0`, and the second input
+  was then written as `conIdx 1` because 1 follows 0. On pattern 4833 the left edge is
+  **`0, 5, 7, 9`** — `1` is the top of the *second column*, a middle slot, and the tool reports it as
+  a violation and forces a regeneration. On 4815 the left edge is `11, 10, 9`, counting *down*.
+  Never derive the next index by adding one.
 
-  **This is not hypothetical.** `DaqReadAndTDMS.vi` was generated on 2026-08-13 with `11`/`8`/`3`/`0`
-  because an earlier revision of this file promised "a generated VI always gets pattern 4815". It
-  came out **4833**, which put both of its remaining inputs on the *output* edge and `error out` in
-  the *top-left* corner. It validated, it ran, and the user rejected it on sight — the second time
-  this same class of mistake has shipped. Do not copy indices out of an NI VI either: those use
-  patterns of their own. Both full maps in `lvai_aixml_reference` §2, "The connector pane".
+  The two station-relevant maps, so the shape is recognisable rather than looked up blind:
+
+  | | 4833 (16 terminals, `5x2x2x2x5`) | 4815 (12 terminals, `4x2x2x4`) |
+  |---|---|---|
+  | first input | 0 | 11 |
+  | more inputs | 5, 7, 9 | 10, 9 |
+  | `error in` | **11** | **8** |
+  | first output | 4 | 3 |
+  | more outputs | 6, 8, 10 | 2, 1 |
+  | `error out` | **15** | **0** |
+
+  Note how far apart they are: `conIdx 0` is top-**left** on 4833 but bottom-**right** on 4815, and
+  `11` is `error in` on one and the *first input* on the other. An earlier revision of this file
+  promised "a generated VI always gets pattern 4815"; a VI authored with `11`/`8`/`3`/`0` came out
+  **4833**, which put both remaining inputs on the *output* edge and `error out` in the top-left
+  corner. It validated, it ran, and the user rejected it on sight. Do not copy indices out of an NI
+  VI either: those use patterns of their own. Both full maps in `lvai_aixml_reference` §2, "The
+  connector pane".
 - **Write AIXML to a file with the `Write` tool.** Never build it in a shell command or a string
   literal: the `\3A` and `\5C` escapes get eaten and the failure arrives disguised as an XML parse
   error, which sends you looking in the wrong place.
@@ -353,33 +372,29 @@ That is expected, and it is the check that your `URL` is right.
 
 ### Phase 7 — The icon, last
 
-`lvai_set_vi_icon` needs an image on disk. A **32x32 PNG** is what was measured — applied as-is,
-and the icon read back out is pixel-identical. Other sizes and formats are untested, so produce
-exactly that. `System.Drawing` is on every Windows box and needs no package:
+**One call. Do not draw the PNG yourself.**
 
-```powershell
-Add-Type -AssemblyName System.Drawing
-$bmp = New-Object System.Drawing.Bitmap 32,32
-$g = [System.Drawing.Graphics]::FromImage($bmp)
-$g.TextRenderingHint = 'SingleBitPerPixelGridFit'   # crisp at 32 px; antialiasing turns to mud
-$g.Clear([System.Drawing.Color]::White)
-$g.FillRectangle((New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(0,90,156))), 0,0,32,9)
-$g.DrawRectangle([System.Drawing.Pens]::Black, 0,0,31,31)
-$f = New-Object System.Drawing.Font 'Segoe UI',5.5,([System.Drawing.FontStyle]::Bold)
-$g.DrawString('FILE',$f,[System.Drawing.Brushes]::White,0,-1)
-$g.DrawString('SORT',$f,[System.Drawing.Brushes]::Black,0,12)
-$g.Dispose()
-$bmp.Save('<abs>\icon.png',[System.Drawing.Imaging.ImageFormat]::Png)
-$bmp.Dispose()
+```
+lvai_set_vi_icon  viPath=<abs>  line1="DAQ"  line2="3AI"  line3="TDMS"
 ```
 
-Design rules that survive 32 px: a coloured banner naming the category, one or two short words
-below it, nothing smaller than ~5.5 pt, and the 1 px black border LabVIEW users expect. Four to
-five characters per line is the ceiling — abbreviate rather than shrink the font.
+`line1` becomes a coloured banner across the top, `line2` and `line3` sit under it, and the tool
+renders the 32x32 PNG, applies it and reads it back. Optional `bannerColor`, `backgroundColor`,
+`borderColor` take `RRGGBB`; the banner defaults to NI blue and the text colour is chosen for
+contrast, so you cannot ask for an unreadable icon. **Five characters per line is the ceiling** —
+abbreviate rather than spill; over-long lines are cut and reported in `warnings`. Drawable:
+`A-Z 0-9 space - . / : + #`, lowercase is upper-cased.
 
-Then `lvai_set_vi_icon` with `viPath` and `iconImagePath`. **Judge the result by the `verified`
-field and by looking at the read-back PNG — not by `errorCode`**, which is 91 on success for the
-same read-back reason as Phase 6.
+This replaced a `PowerShell` + `System.Drawing` recipe that used to live here. Profiling one whole
+generation showed why: **12.5 s went on composing and running that call**, against 0 ms now, and it
+was a separate tool call on top — worth about 11 s of wall clock on its own. If you find yourself
+reaching for `System.Drawing`, you are working from a stale copy of this file.
+
+`iconImagePath` still exists for real artwork. Pass one or the other, never both — the file wins and
+your lines are discarded.
+
+**Judge the result by the `verified` field and by looking at the read-back PNG — not by
+`errorCode`**, which is 91 on success for the same read-back reason as Phase 6.
 
 If you had to regenerate the VI after this, the icon is gone. Re-apply it.
 

--- a/docs/aixml-reference.md
+++ b/docs/aixml-reference.md
@@ -173,11 +173,22 @@ choice either — LabVIEW gives every new VI the default pane from `LabVIEW.ini`
 DefaultConPane="4833"
 ```
 
-That key, read from the `LabVIEW.ini` next to `LabVIEW.exe`, is why everything generated on this
-station comes out 16-terminal. LabVIEW's own default is **4815**, the 12-terminal `4x2x2x4`. So the
-pattern of a *new* VI **is** knowable before you generate — just not from anything inside AIXML or
-the VI Server API. `lvai_connector_pane` with no argument reads it for you and prints the four
-`conIdx` values to write.
+That key, read from the `LabVIEW.ini` next to `LabVIEW.exe`, **overrides everything** — never assume
+a pattern when that file can be read, and it is why everything generated on this station comes out
+16-terminal. **If the key is absent, LabVIEW's factory default applies: 4815, the 12-terminal
+`4x2x2x4`.** So the pattern of a *new* VI **is** knowable before you generate — just not from
+anything inside AIXML or the VI Server API. `lvai_connector_pane` with no argument reads it for you.
+The file is read-only to us: read it, quote it, never write a key to it.
+
+**Take the whole style-guide block that call prints — not four numbers.** This paragraph said "prints
+the four `conIdx` values to write", and that phrasing is itself the cause of a bug that shipped three
+times: the tool prints **six** entries — `first input`, **`more inputs`**, `error in`, `first output`,
+**`more outputs`**, `error out` — and the two `more` rows are the ones a reader drops. A VI with two
+data inputs then gets its first on `conIdx 0`, correctly, and its second on **`conIdx 1`, because 1
+follows 0**. On 4833 the left edge is `0, 5, 7, 9`; `1` is the top of the second column, a middle
+slot. `lvai_connector_pane` with `viPath` catches it and forces a regeneration, so the cost is about
+30 s per occurrence rather than a defect — but **never derive the next index by adding one.** On 4815
+the left edge counts *down*: `11, 10, 9`.
 
 **Three revisions of this section were wrong before that was known, and the shape of the error is
 worth keeping.** The first said a generated VI "essentially always gets 4815" and called that map "a
@@ -577,9 +588,25 @@ that left your source is the string that reached disk.
 
 Same shape, with `maxin` / `maxout` alongside `count`.
 
-**`count` does NOT wire `N`. Nothing does — auto-indexing is the only way to give a For Loop its
-iteration count.** An earlier revision of this line said "`count` carries the iteration count wire",
-which is wrong in both spellings and cost a generation two validate cycles to discover. Measured:
+**`maxin` wires `N`. `count` does not — it names the loop's own `i` output net.** This section said
+for two revisions that *nothing* wires `N` and that auto-indexing was the only way; that was wrong,
+and it pushed at least two generations into building a literal array or a While-Loop counter to get
+a fixed iteration count. The measurements below are all still true — they simply tested the wrong
+attribute. `maxin` was in the attribute vocabulary in §2 the whole time, listed and never tried.
+
+NI's own export of `Flush Written TDMS Data.vi` settles it:
+
+```xml
+<Structure _name="For Loop" count="427.value" maxin="1426.value" maxout="" uid="427" uid_parent="root">
+<Constant outputs="value:1426.value" type="int32" uid="1426" uid_parent="root" value="100"/>
+```
+
+`maxin` takes the net of an int32 constant — that is the `N` terminal — while `count` holds
+`427.value`, the structure's *own* uid, which is the `i` terminal's net. Confirmed in the other
+direction by generating `maxin="210.value"` from an int32 constant `5`: it validated, generated, and
+the round-trip export preserved it, with no indexing tunnel anywhere on the loop.
+
+What `count` is not, measured before `maxin` was tried:
 
 | what was written | answer |
 |---|---|
@@ -588,18 +615,28 @@ which is wrong in both spellings and cost a generation two validate cycles to di
 | `<Tunnel _id="N" …>`, reaching for the terminal itself | **schema violation**: `value 'N' does not match regular expression facet '(In\|Out)[1-9][0-9]*'` |
 | `count=""` plus one `mode="index"` input tunnel | `errorCode 0` |
 
-So the `N` terminal is not addressable in this format at all, and the two extra errors in the second
-row are worth recognising: they name wires and types, they appear *because* `count` holds a net, and
-they vanish when it does not. Anyone chasing them is looking in the wrong place.
+The two extra errors in the second row are worth recognising: they name wires and types, they appear
+*because* `count` holds a net feeding the wrong terminal, and they vanish when it does not. Anyone
+chasing them is looking in the wrong place.
 
-**For a fixed iteration count with no array to index**, index over a literal array of the right
-length — `<Constant type="array{int32}" value="[0,0,0,0,0]"/>` into a `mode="index"` tunnel gives
-`N = 5` — or use a `While Loop` with an int32 shift register, `Increment` and `Greater?` against
-`n-1`, which is what one generated VI settled on and which validates and runs.
+**For a fixed iteration count with no array to index, use `maxin`.** The two workarounds this
+document used to prescribe — indexing over a literal `<Constant type="array{int32}"
+value="[0,0,0,0,0]"/>`, or a `While Loop` with an int32 shift register, `Increment` and `Greater?`
+against `n-1` — both work and both still validate, but neither is necessary and each costs three to
+five extra elements on the diagram.
 
 **Auto-indexing is `mode="index"` on the tunnel** — the attribute the rest of this section was
 missing. A tunnel *without* `mode` passes its whole value through unchanged; with it, the loop
-indexes one element per iteration and supplies `N`. Measured from OpenG's
+indexes one element per iteration and supplies `N`.
+
+**It works on an `Out` tunnel too, which this section only ever showed on `In` tunnels** — that is
+how a loop *builds* an array, one element per iteration, without `Build Array` and a shift register.
+`<Tunnel _id="Out1" inputs="value:530.waveform out" mode="index" outputs="value:540.value"/>`
+validated, generated and round-tripped, and NI's own example exports carry the same shape. The pair
+of them is the whole accumulate-per-channel idiom: index two `In` tunnels, index the `Out` tunnel
+back out.
+
+Measured from OpenG's
 `Filter 1D Array (String)__ogtk.vi`, which is also a compact model of the accumulate-in-a-loop
 idiom:
 
@@ -1507,6 +1544,40 @@ Three things the shape does not show:
 - Reading the result back, a Time Stamp's four I32 words are ordered fraction-low, fraction-high,
   seconds-low, seconds-high — see `vi-server-reference.md`, or every `t0` looks like zero.
 
+### Accumulating an array of waveforms across a loop: two traps
+
+Continuous acquisition hands you one block of N channels per iteration, and the block has to be
+accumulated or all but the last is lost. The obvious shape does not work, and the failure is silent
+rather than an error.
+
+**`Append Waveforms.vi` has no array instance.** `lvai_palette_index` returns exactly one candidate
+(`Categories\Programming\_WaveForm\AnalogWDT.mnu`), and `lvai_vi_terminals` on
+`vi.lib\Waveform\WDTOps.llb\Append Waveforms.vi` shows it is polymorphic with **7 instances, every
+one of them scalar**: `waveform A`, `waveform B`, `error in (no error)` → `waveform out`,
+`error out`. So an accumulator of type `array{doublewaveform}` cannot be appended in one `Call`.
+The correct shape is an **inner For loop that auto-indexes the accumulator and the new block
+together**, one channel per iteration, calling `instance="WDT Append Waveforms DBL.vi"`, with
+`waveform out` auto-indexed back into an array. Rebuilding Y-array concatenation from primitives is
+not needed and is the wrong instinct.
+
+**The empty accumulator makes that loop run zero times.** Initialise the shift register with
+`<Constant type="array{doublewaveform.Waveform}" value="[]"/>` — that type is accepted in `Constant`
+position, measured — and iteration 0 indexes an empty array against an N-element block, so the inner
+For loop runs `min(0, N) = 0` times and the accumulator stays empty **forever**. Nothing reports
+this: it validates, it runs, and the output is an empty array that looks exactly like a device error.
+Guard it with a seed case (`Empty Array?` → `Select`, or a Case on the accumulator's size) that takes
+the first block as-is.
+
+Worth a third frame while you are there. If a *late* read fails and hands the append an empty
+block, the same zero-iteration arithmetic wipes everything already accumulated. A three-way
+selector — seed / append / keep — returns the partial data instead, which is what a caller reading
+`error out` alongside the waveforms will expect.
+
+The symptom that led here: a generated DAQ-to-TDMS VI wired `DAQmx Read`'s `data` straight to the
+output terminal, so four of five blocks were discarded. The user spotted it in the block diagram —
+neither validation nor a run can see it, and on a station without a device the empty output is
+indistinguishable from the expected `-200220`.
+
 ### Reading a CSV: three things about `Read Delimited Spreadsheet` worth not re-deriving
 
 The polymorphic file reader is the standard answer to "load a CSV", and three of its behaviours
@@ -2008,6 +2079,79 @@ Two details that are easy to get wrong and are handled here: output files are na
 alone would have one silently overwrite another; and the path list is split on **newlines only**,
 not on commas, because a comma is legal in a Windows path (`C:\Data\Rev 2, final\`) while a line
 break is not.
+
+### Where a generation session's wall clock actually goes
+
+`CLAUDE.md` has long said that the cost of a generation is round trips rather than LabVIEW, on the
+strength of one session where three `lvai_*` calls took 30.4 s while LabVIEW's own share was 74 ms.
+That was right but thin. Here is the whole profile, taken from subagent transcript timestamps —
+which costs nothing and, unlike having the agent time itself, does not add the very round trips
+being measured. Scripts: `tprof.py` / `tphase.py` in the session scratchpad; attribution is
+`tool exec = tool_result.ts − assistant.ts` and `model turn = assistant.ts − previous.ts`.
+
+One **fresh, complete generation** of a DAQmx-to-TDMS VI by `labview-vi-generator`, 41 tool calls,
+455 s active (idle gaps > 60 s excluded):
+
+| | time | share |
+|---|---|---|
+| text-only turns — reasoning, plans, the final report | **240.3 s** | **52.8 %** |
+| model time in turns that end in a tool call | 146.3 s | 32.2 % |
+| **tool execution — LabVIEW and the MCP server together** | **72.2 s** | **15.9 %** |
+
+A second profile over 54 calls (a generation plus a correction round) agrees: 89.7 s of tool
+execution against 634 s of model turns, **12.5 % vs 88.1 %**.
+
+So the unit worth counting is a tool call, and it is worth about **11 s of wall clock** (455 s / 41)
+regardless of what the call does. That reframes the batching rule in `CLAUDE.md` as arithmetic
+rather than advice:
+
+- `lvai_aixml_reference`, 6 calls in that run, **0.1 s of server time in total** — the document cache
+  did its job — but 6 turns, so roughly 66 s of wall clock. Five of them were avoidable.
+- `lvai_palette_index`, 3 calls, again **0.1 s total**, ~33 s of wall clock.
+
+Batching saves nothing measurable on the server and everything on the clock. A cache on these calls
+would be pointless twice over: they are already sub-millisecond, and no two arguments repeat.
+
+No single `lvai_*` call exceeded 5 s. The expensive ones are exactly the ones that make LabVIEW
+work — `ConvertAIXMLToVI` 3.9 s, `lvai_connector_pane` with `viPath` 4.2 s,
+`lvai_run_vi_and_read_values` 4.0 s, `lvai_set_vi_icon` 3.6 s — and the read-only indexes are free.
+**LabVIEW is not the slow part; it is a sixth of the total.**
+
+By phase, over the 218.5 s that attributes to a tool call:
+
+| phase | calls | model s | tool s | total |
+|---|---|---|---|---|
+| authoring the AIXML — write, edit, validate, convert | 10 | 84.2 | 24.5 | 108.7 s |
+| research — palette, examples, references | 23 | 40.9 | 16.1 | 57.0 s |
+| verification — run, pane, project | 6 | 10.5 | 21.2 | 31.7 s |
+| icon | 2 | 10.7 | 10.4 | 21.1 s |
+
+**Bucket by what a call did, not by which tool ran it.** A first cut of this table charged every
+`Bash` and `PowerShell` call to the icon and reported it at 48.1 s — a fifth of the run — and that
+number was quoted onward before it was checked. Reading the actual commands back out of the
+transcript showed three of those `Bash` calls were `sed`/`python` edits to the AIXML. The icon is
+**21.1 s, under a tenth**; authoring is half the run. Dump the command strings, do not trust the
+tool name.
+
+**Research is 23 of 41 calls**, most individually free, which is where batching has room.
+
+Inside the icon's 21.1 s the split is worth knowing before anyone tries to optimise the VI Server
+side of it: **12.5 s goes on drawing the PNG** (a `PowerShell` call through `System.Drawing`, 6.8 s
+of it, plus 5.7 s of model time composing that call) and only **8.6 s on `lvai_set_vi_icon`** — which
+opens the VI reference, invokes `Set VI Icon from File`, `Save:Instrument` and `Save VI Icon to File`,
+and closes the reference, all in one helper run of 3.6 s. The write-and-read-back chain is already
+minimal; the cost is producing the image, and that never touches LabVIEW.
+
+The other lever is not a call count at all: the largest single turn in the run was **40.3 s of
+reasoning** and the final report cost **30.1 s for 6 001 characters**. Over half the wall clock is
+the model thinking and writing prose. Prescribing what the agent would otherwise derive — the
+station's `conIdx` set, the polymorphic instance name, the accumulator shape — buys more than any
+change on the LabVIEW side can.
+
+A worked example of that, from the same run: the agent authored `TDMS file path` on `conIdx` 1, a
+middle-column slot, and `lvai_connector_pane` flagged it — costing an extra `ConvertAIXMLToVI` and
+an extra pane measurement plus their turns, some 30 s, to arrive at the value the station's
+`DefaultConPane=4833` already fixed before the run began.
 
 ### Where a node's documentation comes from
 

--- a/docs/vi-server-reference.md
+++ b/docs/vi-server-reference.md
@@ -201,6 +201,41 @@ against a freshly generated VI:
 | persist it | `Invoke Node` `Save\3AInstrument` — without it the change dies with the reference |
 | verify | `Invoke Node` `Save VI Icon to File`, input `Image File` |
 
+**The image itself is produced here, not by the caller.** `lvai_set_vi_icon` takes `line1`,
+`line2`, `line3` plus optional `bannerColor` / `backgroundColor` / `borderColor` and renders the
+32×32 PNG in-process before running the helper above — a banner across the top carrying `line1`,
+up to two lines under it, a 1 px frame, five characters per line, drawn from an embedded 5×7 bitmap
+font. `iconImagePath` still accepts real artwork; pass one or the other.
+
+That replaced a `PowerShell` + `System.Drawing` recipe which both agent definitions used to
+prescribe, and the reason is a measurement rather than taste: profiling one whole VI generation (41
+tool calls, 455 s) put the icon at 21.1 s, of which **12.5 s was the caller composing and running
+that PowerShell call** and only 8.6 s was this tool reaching VI Server. Rendering server-side costs
+no measurable time and removes a tool call worth about 11 s of wall clock on its own. The full
+profile is in [`aixml-reference.md`](aixml-reference.md) §10.
+
+Two consequences of the quantisation described below. The default banner is **`006699`, not NI's
+own `005A9C`** — the web-safe neighbour, chosen so the PNG this tool wrote and the icon read back
+out of the VI are the same image. **Measured end to end on `DaqReadAndTDMS.vi`: 0 of 1 024 pixels
+differ**, against 189 of 1 024 for the non-web-safe icon below, and the three colours present
+(`000000`, `006699`, `FFFFFF`) come back untouched. And a caller-supplied colour outside the cube is
+reported in `warnings` together with the value it will actually read back as, rather than being
+silently corrected or silently changed by LabVIEW.
+
+**Compare the decoded pixels, not the PNG bytes.** The same measurement showed LabVIEW writes the
+read-back file as a **palette** PNG (colour type 3) while this tool writes **truecolour** (type 2),
+so the two files differ in length and in almost every byte while encoding an identical image. A
+byte or hash comparison of icon files reports a difference that is not there.
+
+Cost of the whole call, with the helper already generated: **4.39 s and 5.69 s** over two runs, both
+`verified: true`. Too few samples to separate from the 3.6 s measured before rendering moved
+in-process, and the render itself — a 200-byte PNG — cannot account for a second of it; the spread
+is the helper run. What is certain is that the separate `PowerShell` call is gone: 6.8 s of tool
+time and 5.7 s of model time, removed.
+
+A bitmap font rather than a system typeface is also deliberate: at 32 px an anti-aliased TrueType
+glyph turns to mush, which is why the old recipe had to set `SingleBitPerPixelGridFit`.
+
 Four things this measured that the catalogue does not say:
 
 - **`Set VI Icon from File` accepts a 32×32 PNG directly.** Neither `Set VI Icon from Image Data`

--- a/plugin/agents/labview-vi-editor.md
+++ b/plugin/agents/labview-vi-editor.md
@@ -86,9 +86,25 @@ So when the VI has one, validate the **untouched** export before promising anyth
   case last.
 - **Keep the connector pane placed by NI's style guide, and fix it if it is not.** Inputs on the
   **left**, outputs on the **right**, `error in` **bottom left**, `error out` **bottom right**, no
-  crossings. On the standard 4-2-2-4 pane the `conIdx` map is left edge **11, 10, 9, 8** top to
-  bottom and right edge **3, 2, 1, 0** top to bottom, so the usual set is input `11`, `error in`
-  `8`, output `3`, `error out` `0`. Preserving an existing pane is the default — but a pane that
+  crossings. **Which `conIdx` is where depends on the pane pattern, so call `lvai_connector_pane`
+  with the VI's path before you judge a pane and again after you regenerate it** — it measures the
+  pane, names every breach and gives you the corrected assignment. Do not reason from a remembered
+  map: `error in` is `conIdx 8` on the 12-terminal 4815 pane and `11` on the 16-terminal 4833 one, and
+  a generated VI has been measured as either.
+
+  Two things that make a regeneration land on the wrong pane. First, **a full regeneration gets the
+  station's default pane, not the one the VI had** — that default is `DefaultConPane` in the
+  `LabVIEW.ini` beside `LabVIEW.exe`, it **overrides everything**, and `lvai_connector_pane` with
+  **no argument** reads it for you; if the key is absent, LabVIEW's factory default **4815** applies.
+  Read that file, quote it, never write to it. Second, **copy the whole style-guide block the tool
+  prints, not four numbers** — it gives `first input`, **`more inputs`**, `error in`, `first output`,
+  **`more outputs`**, `error out`, and the two `more` entries are the ones that get dropped.
+  **Consecutive `conIdx` is not the left edge**: on 4833 that edge is `0, 5, 7, 9`, so a second input
+  written as `1` lands in a middle column. That exact slip has shipped three times.
+
+  This paragraph used to give the 4-2-2-4 map as a flat constant — input `11`, `error in` `8`, output
+  `3`, `error out` `0` — which is right for 4815 and wrong for whatever the station is actually set
+  to. Preserving an existing pane is the default — but a pane that
   breaks the guide is a defect worth naming in the report and correcting, since `conIdx` is one
   attribute per terminal and costs nothing to change. Detail in `lvai_aixml_reference` §2, "The
   connector pane".
@@ -331,26 +347,20 @@ was the old workaround and cost about eight minutes of hand-built harness per VI
 
 `lvai_set_vi_icon` with `viPath` and `iconImagePath` = `icon_before.png`.
 
-If Phase 4 found no real icon, make one instead — 32x32 PNG, which is the only size and format
-measured:
+If Phase 4 found no real icon, have the tool draw one instead — **one call, no PowerShell**:
 
-```powershell
-Add-Type -AssemblyName System.Drawing
-$bmp = New-Object System.Drawing.Bitmap 32,32
-$g = [System.Drawing.Graphics]::FromImage($bmp)
-$g.TextRenderingHint = 'SingleBitPerPixelGridFit'   # crisp at 32 px; antialiasing turns to mud
-$g.Clear([System.Drawing.Color]::White)
-$g.FillRectangle((New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(0,90,156))), 0,0,32,9)
-$g.DrawRectangle([System.Drawing.Pens]::Black, 0,0,31,31)
-$f = New-Object System.Drawing.Font 'Segoe UI',5.5,([System.Drawing.FontStyle]::Bold)
-$g.DrawString('FILE',$f,[System.Drawing.Brushes]::White,0,-1)
-$g.DrawString('SORT',$f,[System.Drawing.Brushes]::Black,0,12)
-$g.Dispose()
-$bmp.Save('<abs>\icon.png',[System.Drawing.Imaging.ImageFormat]::Png)
-$bmp.Dispose()
+```
+lvai_set_vi_icon  viPath=<abs>  line1="FILE"  line2="SORT"
 ```
 
-Four to five characters per line is the ceiling; abbreviate rather than shrink the font.
+`line1` becomes a coloured banner, `line2` and `line3` sit under it, and the tool renders the 32x32
+PNG itself. Optional `bannerColor`, `backgroundColor`, `borderColor` as `RRGGBB`; text colour is
+picked for contrast. **Five characters per line is the ceiling** — abbreviate rather than spill;
+longer lines are cut and reported in `warnings`. Drawable: `A-Z 0-9 space - . / : + #`.
+
+A `PowerShell` + `System.Drawing` recipe used to stand here. It was measured at **12.5 s** of a
+generation session, plus a whole extra tool call, against 0 ms now. Reaching for `System.Drawing`
+means you are reading a stale copy of this file.
 
 Judge the result by the `verified` field and by looking at the read-back PNG — **not** by
 `errorCode`, which is 91 on success. If you regenerate again afterwards, the icon is gone again:

--- a/plugin/agents/labview-vi-generator.md
+++ b/plugin/agents/labview-vi-generator.md
@@ -62,22 +62,44 @@ it an icon.
      instance` for a primitive, or you need a *mode* variant (§8 records terminals, not modes).
 - **Place the connector pane by NI's style guide — this is not cosmetic, it is the first thing a
   reviewer sees.** Inputs on the **left**, outputs on the **right**, `error in` **bottom left**,
-  `error out` **bottom right**, nothing arranged so wires must cross. **A generated VI always gets
-  pattern 4815** — measured with the highest index at 3, 7 and 11, all three came out the same, and
-  there is no attribute to ask for another — so this map is a constant, not something to derive:
+  `error out` **bottom right**, nothing arranged so wires must cross. **Which `conIdx` sits where
+  depends on the pane pattern, so ask `lvai_connector_pane` and do not reason about it:**
 
-  | | `conIdx`, top → bottom |
-  |---|---|
-  | **left edge — inputs** | **11, 10, 9, 8** — put `error in` on **8** |
-  | middle columns | 7/6, then 5/4 (upper/lower) — secondary terminals only |
-  | **right edge — outputs** | **3, 2, 1, 0** — put `error out` on **0** |
+  1. **Before** you write any `conIdx`, call `lvai_connector_pane` with **no argument**. LabVIEW gives
+     every new VI the station's default pane, read from **`DefaultConPane` in the `LabVIEW.ini` beside
+     `LabVIEW.exe`**, and that key **overrides everything** — never assume a pattern when the file can
+     be read. If the key is absent, LabVIEW's factory default **4815** applies. That file is read-only
+     to us: read it, quote it, never write to it.
+  2. **Copy the WHOLE style-guide block the tool prints, not four numbers.** It gives six entries —
+     `first input`, **`more inputs`**, `error in`, `first output`, **`more outputs`**, `error out`.
+     The two in bold are the ones that get dropped, and dropping them is the actual bug below.
+  3. Author the AIXML with exactly those numbers.
+  4. After generating, call it again with `viPath`. That confirms the pane you actually got and checks
+     every terminal against the style guide. Read-only, about 1 s per call.
 
-  So a typical VI is: main input `11`, `error in` `8`, main output `3`, second output `2`,
-  `error out` `0`. **Do not invent an assignment by analogy** — a generated VI shipped with both
-  inputs on the right-hand edge and all three outputs in the middle columns, validated, ran, and
-  was rejected on sight. And do not copy a set of indices out of an NI VI: those use other
-  patterns, where the same numbers are different slots. Above 12 terminals the pattern changes and
-  this map no longer holds; detail in `lvai_aixml_reference` §2, "The connector pane".
+  **Consecutive `conIdx` is NOT the left edge.** This is the trap, and it has now shipped three
+  times in `DaqReadAndTDMS.vi`: the first input went correctly to `conIdx 0`, and the second input
+  was then written as `conIdx 1` because 1 follows 0. On pattern 4833 the left edge is
+  **`0, 5, 7, 9`** — `1` is the top of the *second column*, a middle slot, and the tool reports it as
+  a violation and forces a regeneration. On 4815 the left edge is `11, 10, 9`, counting *down*.
+  Never derive the next index by adding one.
+
+  | | 4833 (16 terminals, `5x2x2x2x5`) | 4815 (12 terminals, `4x2x2x4`) |
+  |---|---|---|
+  | first input | 0 | 11 |
+  | more inputs | 5, 7, 9 | 10, 9 |
+  | `error in` | **11** | **8** |
+  | first output | 4 | 3 |
+  | more outputs | 6, 8, 10 | 2, 1 |
+  | `error out` | **15** | **0** |
+
+  `conIdx 0` is top-**left** on 4833 but bottom-**right** on 4815, and `11` is `error in` on one and
+  the *first input* on the other. **This paragraph used to claim "a generated VI always gets pattern
+  4815, so this map is a constant".** That was measured, it did not generalise, and it is how a VI
+  shipped with both inputs on the *output* edge and `error out` in the top-left corner — it validated,
+  it ran, and the user rejected it on sight. The pattern is a station setting, not a constant. Do not
+  copy indices out of an NI VI either: those use patterns of their own. Both full maps in
+  `lvai_aixml_reference` §2, "The connector pane".
 - **Write AIXML to a file with the `Write` tool.** Never build it in a shell command or a string
   literal: the `\3A` and `\5C` escapes get eaten and the failure arrives disguised as an XML parse
   error, which sends you looking in the wrong place.
@@ -322,29 +344,26 @@ That is expected, and it is the check that your `URL` is right.
 
 ### Phase 7 — The icon, last
 
-`lvai_set_vi_icon` needs an image on disk. A **32x32 PNG** is what was measured — applied as-is,
-and the icon read back out is pixel-identical. Other sizes and formats are untested, so produce
-exactly that. `System.Drawing` is on every Windows box and needs no package:
+**One call. Do not draw the PNG yourself.**
 
-```powershell
-Add-Type -AssemblyName System.Drawing
-$bmp = New-Object System.Drawing.Bitmap 32,32
-$g = [System.Drawing.Graphics]::FromImage($bmp)
-$g.TextRenderingHint = 'SingleBitPerPixelGridFit'   # crisp at 32 px; antialiasing turns to mud
-$g.Clear([System.Drawing.Color]::White)
-$g.FillRectangle((New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(0,90,156))), 0,0,32,9)
-$g.DrawRectangle([System.Drawing.Pens]::Black, 0,0,31,31)
-$f = New-Object System.Drawing.Font 'Segoe UI',5.5,([System.Drawing.FontStyle]::Bold)
-$g.DrawString('FILE',$f,[System.Drawing.Brushes]::White,0,-1)
-$g.DrawString('SORT',$f,[System.Drawing.Brushes]::Black,0,12)
-$g.Dispose()
-$bmp.Save('<abs>\icon.png',[System.Drawing.Imaging.ImageFormat]::Png)
-$bmp.Dispose()
+```
+lvai_set_vi_icon  viPath=<abs>  line1="DAQ"  line2="3AI"  line3="TDMS"
 ```
 
-Design rules that survive 32 px: a coloured banner naming the category, one or two short words
-below it, nothing smaller than ~5.5 pt, and the 1 px black border LabVIEW users expect. Four to
-five characters per line is the ceiling — abbreviate rather than shrink the font.
+`line1` becomes a coloured banner across the top, `line2` and `line3` sit under it, and the tool
+renders the 32x32 PNG, applies it and reads it back. Optional `bannerColor`, `backgroundColor`,
+`borderColor` take `RRGGBB`; the banner defaults to NI blue and the text colour is chosen for
+contrast, so you cannot ask for an unreadable icon. **Five characters per line is the ceiling** —
+abbreviate rather than spill; over-long lines are cut and reported in `warnings`. Drawable:
+`A-Z 0-9 space - . / : + #`, lowercase is upper-cased.
+
+This replaced a `PowerShell` + `System.Drawing` recipe that used to live here. Profiling one whole
+generation showed why: **12.5 s went on composing and running that call**, against 0 ms now, and it
+was a separate tool call on top — worth about 11 s of wall clock on its own. If you find yourself
+reaching for `System.Drawing`, you are working from a stale copy of this file.
+
+`iconImagePath` still exists for real artwork. Pass one or the other, never both — the file wins and
+your lines are discarded.
 
 Then `lvai_set_vi_icon` with `viPath` and `iconImagePath`. **Judge the result by the `verified`
 field and by looking at the read-back PNG — not by `errorCode`**, which is 91 on success for the

--- a/src/LabVIEWMCP/Infra/IconImage.cs
+++ b/src/LabVIEWMCP/Infra/IconImage.cs
@@ -1,0 +1,296 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+
+namespace LabVIEWMcp.Infra;
+
+/// <summary>
+/// Draws a 32x32 LabVIEW icon and encodes it as a PNG, with no imaging dependency.
+///
+/// This exists because of a measurement, not for elegance. Profiling one whole VI generation
+/// (41 tool calls, 455 s) showed the icon costing 21.1 s, of which only 8.6 s was
+/// lvai_set_vi_icon actually reaching VI Server - the other 12.5 s was an agent composing and
+/// running a PowerShell call that drew the bitmap through System.Drawing. Producing the image
+/// server-side removes that step and one whole tool call with it, and a tool call is worth about
+/// 11 s of wall clock in a generation session. Numbers in docs/aixml-reference.md.
+///
+/// Dependency-free is deliberate. System.Drawing.Common is Windows-only and a package; a PNG
+/// encoder for one fixed size is about eighty lines, and IconTools already reads PNG headers by
+/// hand for exactly the same reason. Text is drawn from an embedded 5x7 bitmap font rather than
+/// a system typeface: at 32 px an anti-aliased TrueType glyph turns to mush, and a bitmap font
+/// is what LabVIEW icons have always used.
+/// </summary>
+internal static class IconImage
+{
+    internal const int Size = 32;
+
+    /// <summary>5 px glyph + 1 px gap inside a 30 px writable width: 6n-1 &lt;= 30.</summary>
+    internal const int MaxCharsPerLine = 5;
+
+    private const int GlyphWidth = 5;
+    private const int GlyphHeight = 7;
+
+    /// <summary>
+    /// The character order of <see cref="GlyphRows"/>. Uppercase only - a 5x7 cell has no room
+    /// for descenders, so lowercase input is upper-cased rather than rendered badly.
+    /// </summary>
+    private const string Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -./:+#";
+
+    /// <summary>
+    /// Seven rows per glyph, in <see cref="Alphabet"/> order. Bit 4 (0b10000) is the leftmost
+    /// pixel, so a row reads left to right as written.
+    /// </summary>
+    private static readonly byte[] GlyphRows =
+    [
+        0x0E, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11,   // A
+        0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E,   // B
+        0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E,   // C
+        0x1E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1E,   // D
+        0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x1F,   // E
+        0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x10,   // F
+        0x0E, 0x11, 0x10, 0x17, 0x11, 0x11, 0x0E,   // G
+        0x11, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11,   // H
+        0x1F, 0x04, 0x04, 0x04, 0x04, 0x04, 0x1F,   // I
+        0x07, 0x02, 0x02, 0x02, 0x02, 0x12, 0x0C,   // J
+        0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11,   // K
+        0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1F,   // L
+        0x11, 0x1B, 0x15, 0x15, 0x11, 0x11, 0x11,   // M
+        0x11, 0x11, 0x19, 0x15, 0x13, 0x11, 0x11,   // N
+        0x0E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E,   // O
+        0x1E, 0x11, 0x11, 0x1E, 0x10, 0x10, 0x10,   // P
+        0x0E, 0x11, 0x11, 0x11, 0x15, 0x13, 0x0D,   // Q
+        0x1E, 0x11, 0x11, 0x1E, 0x14, 0x12, 0x11,   // R
+        0x0F, 0x10, 0x10, 0x0E, 0x01, 0x01, 0x1E,   // S
+        0x1F, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,   // T
+        0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E,   // U
+        0x11, 0x11, 0x11, 0x11, 0x11, 0x0A, 0x04,   // V
+        0x11, 0x11, 0x11, 0x15, 0x15, 0x1B, 0x11,   // W
+        0x11, 0x11, 0x0A, 0x04, 0x0A, 0x11, 0x11,   // X
+        0x11, 0x11, 0x0A, 0x04, 0x04, 0x04, 0x04,   // Y
+        0x1F, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1F,   // Z
+        0x0E, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0E,   // 0
+        0x04, 0x0C, 0x04, 0x04, 0x04, 0x04, 0x0E,   // 1
+        0x0E, 0x11, 0x01, 0x02, 0x04, 0x08, 0x1F,   // 2
+        0x1F, 0x02, 0x04, 0x02, 0x01, 0x11, 0x0E,   // 3
+        0x02, 0x06, 0x0A, 0x12, 0x1F, 0x02, 0x02,   // 4
+        0x1F, 0x10, 0x1E, 0x01, 0x01, 0x11, 0x0E,   // 5
+        0x06, 0x08, 0x10, 0x1E, 0x11, 0x11, 0x0E,   // 6
+        0x1F, 0x01, 0x02, 0x04, 0x08, 0x08, 0x08,   // 7
+        0x0E, 0x11, 0x11, 0x0E, 0x11, 0x11, 0x0E,   // 8
+        0x0E, 0x11, 0x11, 0x0F, 0x01, 0x02, 0x0C,   // 9
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,   // space
+        0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00,   // -
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x06,   // .
+        0x01, 0x01, 0x02, 0x04, 0x08, 0x10, 0x10,   // /
+        0x00, 0x06, 0x06, 0x00, 0x06, 0x06, 0x00,   // :
+        0x00, 0x04, 0x04, 0x1F, 0x04, 0x04, 0x00,   // +
+        0x0A, 0x1F, 0x0A, 0x0A, 0x0A, 0x1F, 0x0A,   // #
+    ];
+
+    /// <summary>An 8-bit-per-channel colour. No alpha: LabVIEW icons are opaque.</summary>
+    internal readonly record struct Rgb(byte R, byte G, byte B);
+
+    /// <summary>
+    /// Parse "RRGGBB" or "#RRGGBB". Returns null for anything else, so a caller can report the
+    /// offending string rather than silently drawing black.
+    /// </summary>
+    internal static Rgb? ParseColor(string? text)
+    {
+        if (text is null) return null;
+        var hex = text.Trim().TrimStart('#');
+        if (hex.Length != 6) return null;
+        return byte.TryParse(hex.AsSpan(0, 2), System.Globalization.NumberStyles.HexNumber, null, out var r)
+            && byte.TryParse(hex.AsSpan(2, 2), System.Globalization.NumberStyles.HexNumber, null, out var g)
+            && byte.TryParse(hex.AsSpan(4, 2), System.Globalization.NumberStyles.HexNumber, null, out var b)
+            ? new Rgb(r, g, b)
+            : null;
+    }
+
+    /// <summary>
+    /// Black or white, whichever stays legible on <paramref name="background"/>. Chosen from the fill rather than
+    /// exposed as two more parameters, because the one thing a caller must not be able to do is
+    /// ask for an icon whose text cannot be read. Rec. 601 luma, threshold at the midpoint.
+    /// </summary>
+    internal static Rgb ReadableOn(Rgb background) =>
+        (299 * background.R + 587 * background.G + 114 * background.B) / 1000 < 128
+            ? new Rgb(0xFF, 0xFF, 0xFF)
+            : new Rgb(0x00, 0x00, 0x00);
+
+    /// <summary>
+    /// The six values LabVIEW quantises each channel to. Measured, not assumed - see
+    /// vi-server-reference.md, "Writing back: setting a VI's icon": an icon read back out of a VI
+    /// has every channel in this set, 189 of 1 024 pixels having moved on a non-web-safe image.
+    /// </summary>
+    private static readonly byte[] WebSafe = [0x00, 0x33, 0x66, 0x99, 0xCC, 0xFF];
+
+    /// <summary>Whether LabVIEW will store this colour unchanged.</summary>
+    internal static bool IsWebSafe(Rgb c) =>
+        WebSafe.Contains(c.R) && WebSafe.Contains(c.G) && WebSafe.Contains(c.B);
+
+    /// <summary>What LabVIEW will turn this colour into, so a caller can be told up front.</summary>
+    internal static Rgb Quantise(Rgb c) => new(Nearest(c.R), Nearest(c.G), Nearest(c.B));
+
+    private static byte Nearest(byte channel)
+    {
+        var best = WebSafe[0];
+        foreach (var candidate in WebSafe)
+            if (Math.Abs(candidate - channel) < Math.Abs(best - channel)) best = candidate;
+        return best;
+    }
+
+    /// <summary>Whether the font can draw this character, after upper-casing.</summary>
+    internal static bool Supports(char c) => Alphabet.IndexOf(char.ToUpperInvariant(c)) >= 0;
+
+    /// <summary>
+    /// Everything in <paramref name="text"/> the font cannot draw, de-duplicated, so the tool can
+    /// warn about it instead of quietly leaving gaps.
+    /// </summary>
+    internal static string Unsupported(string? text) =>
+        text is null ? "" : new string(text.Where(c => !Supports(c)).Distinct().ToArray());
+
+    /// <summary>
+    /// A 32x32 PNG: 1 px border, a coloured banner across the top carrying
+    /// <paramref name="line1"/> in <paramref name="bannerText"/>, and up to two more lines below
+    /// it on <paramref name="background"/>. Lines longer than <see cref="MaxCharsPerLine"/> are
+    /// truncated - the caller is expected to have warned already.
+    /// </summary>
+    internal static byte[] Render(
+        string? line1, string? line2, string? line3,
+        Rgb banner, Rgb background, Rgb border, Rgb bannerText, Rgb bodyText)
+    {
+        var pixels = new Rgb[Size * Size];
+        Array.Fill(pixels, background);
+
+        // Banner rows 1..9: nine rows is a 7 px glyph with a pixel of air above and below.
+        for (var y = 1; y <= 9; y++)
+            for (var x = 1; x < Size - 1; x++)
+                pixels[y * Size + x] = banner;
+
+        // Border last would be wrong only if the banner overwrote it; it does not, but drawing
+        // the frame after the fill keeps the corners exact whatever the fill does later.
+        for (var i = 0; i < Size; i++)
+        {
+            pixels[i] = border;                          // top
+            pixels[(Size - 1) * Size + i] = border;      // bottom
+            pixels[i * Size] = border;                   // left
+            pixels[i * Size + Size - 1] = border;        // right
+        }
+
+        DrawLine(pixels, line1, 2, bannerText);
+        DrawLine(pixels, line2, 12, bodyText);
+        DrawLine(pixels, line3, 21, bodyText);
+
+        return Encode(pixels);
+    }
+
+    /// <summary>Draw one centred line with its top row at <paramref name="top"/>.</summary>
+    private static void DrawLine(Rgb[] pixels, string? text, int top, Rgb colour)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return;
+
+        var chars = text.Trim().ToUpperInvariant();
+        if (chars.Length > MaxCharsPerLine) chars = chars[..MaxCharsPerLine];
+
+        var width = chars.Length * (GlyphWidth + 1) - 1;
+        var x0 = (Size - width) / 2;
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var index = Alphabet.IndexOf(chars[i]);
+            if (index < 0) continue;                      // reported by Unsupported(), not drawn
+
+            for (var row = 0; row < GlyphHeight; row++)
+            {
+                var bits = GlyphRows[index * GlyphHeight + row];
+                for (var col = 0; col < GlyphWidth; col++)
+                {
+                    if ((bits & (1 << (GlyphWidth - 1 - col))) == 0) continue;
+                    var x = x0 + i * (GlyphWidth + 1) + col;
+                    var y = top + row;
+                    if (x > 0 && x < Size - 1 && y > 0 && y < Size - 1)
+                        pixels[y * Size + x] = colour;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Encode as 8-bit truecolour PNG: signature, IHDR, one IDAT, IEND. Each scanline is
+    /// prefixed with filter type 0 (none) - at 32x32 a filter would save bytes nobody counts.
+    /// </summary>
+    private static byte[] Encode(Rgb[] pixels)
+    {
+        var raw = new byte[Size * (1 + Size * 3)];
+        var at = 0;
+        for (var y = 0; y < Size; y++)
+        {
+            raw[at++] = 0;                                // filter: none
+            for (var x = 0; x < Size; x++)
+            {
+                var p = pixels[y * Size + x];
+                raw[at++] = p.R;
+                raw[at++] = p.G;
+                raw[at++] = p.B;
+            }
+        }
+
+        using var deflated = new MemoryStream();
+        // PNG's IDAT is a zlib stream (RFC 1950), which is exactly what ZLibStream writes -
+        // DeflateStream would emit a raw deflate stream and every decoder would reject it.
+        using (var zlib = new ZLibStream(deflated, CompressionLevel.Optimal, leaveOpen: true))
+            zlib.Write(raw, 0, raw.Length);
+
+        var ihdr = new byte[13];
+        BinaryPrimitives.WriteInt32BigEndian(ihdr.AsSpan(0, 4), Size);
+        BinaryPrimitives.WriteInt32BigEndian(ihdr.AsSpan(4, 4), Size);
+        ihdr[8] = 8;      // bit depth
+        ihdr[9] = 2;      // colour type 2: truecolour RGB
+        ihdr[10] = 0;     // compression: deflate
+        ihdr[11] = 0;     // filter method 0
+        ihdr[12] = 0;     // no interlace
+
+        using var png = new MemoryStream();
+        png.Write([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        WriteChunk(png, "IHDR", ihdr);
+        WriteChunk(png, "IDAT", deflated.ToArray());
+        WriteChunk(png, "IEND", []);
+        return png.ToArray();
+    }
+
+    private static void WriteChunk(Stream target, string type, ReadOnlySpan<byte> data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        target.Write(length);
+
+        var typed = new byte[4 + data.Length];
+        for (var i = 0; i < 4; i++) typed[i] = (byte)type[i];
+        data.CopyTo(typed.AsSpan(4));
+        target.Write(typed);
+
+        Span<byte> crc = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(crc, Crc32(typed));
+        target.Write(crc);
+    }
+
+    private static readonly uint[] CrcTable = BuildCrcTable();
+
+    private static uint[] BuildCrcTable()
+    {
+        var table = new uint[256];
+        for (uint n = 0; n < 256; n++)
+        {
+            var c = n;
+            for (var k = 0; k < 8; k++)
+                c = (c & 1) != 0 ? 0xEDB88320u ^ (c >> 1) : c >> 1;
+            table[n] = c;
+        }
+        return table;
+    }
+
+    private static uint Crc32(ReadOnlySpan<byte> data)
+    {
+        var c = 0xFFFFFFFFu;
+        foreach (var b in data) c = CrcTable[(c ^ b) & 0xFF] ^ (c >> 8);
+        return c ^ 0xFFFFFFFFu;
+    }
+}

--- a/src/LabVIEWMCP/Tools/IconTools.cs
+++ b/src/LabVIEWMCP/Tools/IconTools.cs
@@ -32,6 +32,12 @@ internal sealed class IconTools(LvaiConnection connection)
         scripts\lvdoc_set_icon.xml (once, then reused), run it, read the icon back out.
         Measured on LabVIEW 2026: a 32x32 PNG is applied as-is and the icon read back out of
         the VI is pixel-identical. Other formats and sizes are untested.
+        TWO WAYS TO SUPPLY THE IMAGE. Either pass line1/line2/line3 and let this DRAW the
+        32x32 icon for you - banner across the top plus up to two lines under it, 5 characters
+        per line, from a built-in bitmap font - or pass iconImagePath if you have your own art.
+        PREFER THE LINES: drawing the PNG yourself through PowerShell and System.Drawing was
+        measured at 12.5 s of a generation session, against 0 ms here, and it costs an extra
+        tool call worth about 11 s of wall clock on top.
         CALL THIS LAST. lvai_convert_aixml_to_vi over an existing path DESTROYS the icon -
         measured on two VIs - so re-apply after every regeneration. It is safe in the other
         direction: setting an icon does not leave the VI in memory, so the path can still be
@@ -43,8 +49,12 @@ internal sealed class IconTools(LvaiConnection connection)
     public async Task<string> SetViIconAsync(
         [Description(@"Absolute path to the .vi whose icon is replaced - it is saved in place")]
         string viPath,
-        [Description(@"Absolute path to the icon image. A 32x32 PNG is what was measured")]
-        string iconImagePath,
+        [Description("""
+            Absolute path to a ready-made icon image; a 32x32 PNG is what was measured. Leave
+            this out and pass line1/line2/line3 instead to have the icon drawn here. If both
+            are given the file wins and the lines are reported as ignored.
+            """)]
+        string? iconImagePath = null,
         [Description("""
             Where to write the icon read back OUT of the VI afterwards, for verification.
             Defaults to a temp file. Its directory is created if missing - LabVIEW's own file
@@ -64,14 +74,73 @@ internal sealed class IconTools(LvaiConnection connection)
         string? helperAixmlPath = null,
         [Description("Regenerate the helper VI even when it already exists")]
         bool regenerateHelper = false,
+        [Description("""
+            Text for the coloured banner across the top of a drawn icon, e.g. "DAQ". Up to 5
+            characters; A-Z, 0-9, space and - . / : + # are drawn, anything else is reported.
+            Lowercase is upper-cased - a 5x7 cell has no room for descenders.
+            """)]
+        string? line1 = null,
+        [Description("Second line of a drawn icon, under the banner. Up to 5 characters")]
+        string? line2 = null,
+        [Description("Third line of a drawn icon. Up to 5 characters")]
+        string? line3 = null,
+        [Description("""
+            Banner colour of a drawn icon as RRGGBB or #RRGGBB. Defaults to 006699, the web-safe
+            neighbour of NI blue - LabVIEW quantises a stored icon to the web-safe cube, so a
+            colour outside it reads back changed and is reported in warnings.
+            """)]
+        string? bannerColor = null,
+        [Description(@"Body background of a drawn icon as RRGGBB. Defaults to white FFFFFF")]
+        string? backgroundColor = null,
+        [Description(@"1 px frame of a drawn icon as RRGGBB. Defaults to black 000000")]
+        string? borderColor = null,
         [Description("Local budget in seconds")] int timeoutSeconds = 300,
         CancellationToken ct = default) =>
         await Rpc.GuardAsync(async () =>
         {
             if (!File.Exists(viPath))
                 throw new FileNotFoundException($"No VI at '{viPath}'.", viPath);
-            if (!File.Exists(iconImagePath))
-                throw new FileNotFoundException($"No icon image at '{iconImagePath}'.", iconImagePath);
+
+            // Notes gathered while working out the image, folded into `warnings` further down.
+            // They are warnings, never errors: a cut line or an undrawable character still
+            // produces a usable icon, and failing the whole call over one would be worse.
+            var imageNotes = new List<string>();
+            var iconRendered = false;
+
+            if (iconImagePath is { Length: > 0 })
+            {
+                if (!File.Exists(iconImagePath))
+                    throw new FileNotFoundException($"No icon image at '{iconImagePath}'.", iconImagePath);
+                if (HasAnyLine(line1, line2, line3))
+                    imageNotes.Add("Both iconImagePath and line1/line2/line3 were given. The file was " +
+                                   "used and the lines were ignored.");
+            }
+            else if (HasAnyLine(line1, line2, line3))
+            {
+                var banner = Colour(bannerColor, NiBlue, nameof(bannerColor), imageNotes);
+                var background = Colour(backgroundColor, White, nameof(backgroundColor), imageNotes);
+                var border = Colour(borderColor, Black, nameof(borderColor), imageNotes);
+
+                foreach (var (line, name) in new[]
+                         { (line1, nameof(line1)), (line2, nameof(line2)), (line3, nameof(line3)) })
+                    NoteLineProblems(line, name, imageNotes);
+
+                iconImagePath = Path.GetFullPath(DefaultRenderedIconPath(viPath));
+                EnsureDirectoryOf(iconImagePath);
+                await File.WriteAllBytesAsync(iconImagePath,
+                    IconImage.Render(line1, line2, line3, banner, background, border,
+                                     IconImage.ReadableOn(banner), IconImage.ReadableOn(background)),
+                    ct);
+                iconRendered = true;
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "Nothing to apply: pass line1 (and optionally line2/line3) to have a 32x32 icon " +
+                    "drawn here, or iconImagePath to use your own image. Drawing is cheaper - " +
+                    "producing the PNG yourself costs an extra tool call and about 12 s.",
+                    nameof(line1));
+            }
 
             var aixml = helperAixmlPath ?? DefaultHelperAixmlPath()
                 ?? throw new FileNotFoundException(
@@ -117,6 +186,7 @@ internal sealed class IconTools(LvaiConnection connection)
                         && readBackAfter.WriteUtc >= runStartedUtc.AddSeconds(-2);
 
             var warnings = new JsonArray();
+            foreach (var note in imageNotes) warnings.Add(note);
             var iconSize = PngSize(iconImagePath);
             if (iconSize is null)
                 warnings.Add("The icon image is not a PNG. Only 32x32 PNG has been measured.");
@@ -138,6 +208,8 @@ internal sealed class IconTools(LvaiConnection connection)
                 ("readBackPath", JsonValue.Create(readBack)),
                 ("readBackBytes", JsonValue.Create(readBackAfter.Bytes)),
                 ("readBackSize", JsonValue.Create(readBackAfter.Exists ? PngSize(readBack) : null)),
+                ("iconImagePath", JsonValue.Create(iconImagePath)),
+                ("iconRendered", JsonValue.Create(iconRendered)),
                 ("iconImageSize", JsonValue.Create(iconSize)),
                 ("warnings", warnings),
                 ("note", JsonValue.Create(
@@ -200,6 +272,63 @@ internal sealed class IconTools(LvaiConnection connection)
             });
     }
 
+    /// <summary>
+    /// NI blue is 005A9C, and this is deliberately its web-safe neighbour instead. LabVIEW
+    /// quantises a stored icon to the web-safe cube (vi-server-reference.md), so 005A9C would come
+    /// back out as 006699 anyway - defaulting to the value that survives means the PNG this tool
+    /// wrote and the icon read back out of the VI are the same image, and comparing them is
+    /// therefore meaningful rather than a guaranteed mismatch.
+    /// </summary>
+    private static readonly IconImage.Rgb NiBlue = new(0x00, 0x66, 0x99);
+    private static readonly IconImage.Rgb White = new(0xFF, 0xFF, 0xFF);
+    private static readonly IconImage.Rgb Black = new(0x00, 0x00, 0x00);
+
+    private static bool HasAnyLine(params string?[] lines) =>
+        lines.Any(l => !string.IsNullOrWhiteSpace(l));
+
+    /// <summary>
+    /// Parse a colour, or fall back to the default and say so. An unparseable colour is not worth
+    /// failing the call over - but it is worth reporting, because silently drawing the default is
+    /// how a caller comes to believe the parameter does nothing.
+    /// </summary>
+    private static IconImage.Rgb Colour(
+        string? text, IconImage.Rgb fallback, string parameter, List<string> notes)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return fallback;
+
+        if (IconImage.ParseColor(text) is not { } parsed)
+        {
+            notes.Add($"{parameter} '{text}' is not RRGGBB or #RRGGBB and was ignored; " +
+                      $"used {Hex(fallback)} instead.");
+            return fallback;
+        }
+
+        // Not an error and not corrected: the caller asked for this colour, and saying what
+        // LabVIEW will do with it beats letting them discover it from the read-back.
+        if (!IconImage.IsWebSafe(parsed))
+            notes.Add($"{parameter} {Hex(parsed)} is not web-safe. LabVIEW quantises a stored icon " +
+                      $"to the web-safe cube, so it will read back as {Hex(IconImage.Quantise(parsed))}.");
+
+        return parsed;
+    }
+
+    private static string Hex(IconImage.Rgb c) => $"{c.R:X2}{c.G:X2}{c.B:X2}";
+
+    private static void NoteLineProblems(string? line, string parameter, List<string> notes)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return;
+
+        var trimmed = line.Trim();
+        if (trimmed.Length > IconImage.MaxCharsPerLine)
+            notes.Add($"{parameter} is {trimmed.Length} characters. Only the first " +
+                      $"{IconImage.MaxCharsPerLine} fit across a 32x32 icon; the rest was cut, " +
+                      $"leaving '{trimmed[..IconImage.MaxCharsPerLine]}'.");
+
+        if (IconImage.Unsupported(trimmed) is { Length: > 0 } missing)
+            notes.Add($"{parameter} contains characters the icon font cannot draw, left blank: " +
+                      $"'{missing}'. Drawable: A-Z, 0-9, space, - . / : + #");
+    }
+
     private static void EnsureDirectoryOf(string filePath)
     {
         if (Path.GetDirectoryName(filePath) is { Length: > 0 } directory)
@@ -224,6 +353,15 @@ internal sealed class IconTools(LvaiConnection connection)
     /// </summary>
     private static string DefaultHelperViPath() =>
         Path.Combine(Path.GetTempPath(), "LabVIEWMCP", "helpers", "lvdoc_set_icon.vi");
+
+    /// <summary>
+    /// Where a drawn icon lands. Kept rather than written to a scratch file and deleted: the
+    /// response reports the path, and being able to open the PNG that was sent to LabVIEW is how
+    /// you tell "the icon is wrong" from "the icon did not apply".
+    /// </summary>
+    private static string DefaultRenderedIconPath(string viPath) =>
+        Path.Combine(Path.GetTempPath(), "LabVIEWMCP",
+            $"{Path.GetFileNameWithoutExtension(viPath)}-icon.png");
 
     private static string DefaultReadBackPath(string viPath) =>
         Path.Combine(Path.GetTempPath(), "LabVIEWMCP",

--- a/tests/LabVIEWMCP.Tests/Infra/IconImageTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/IconImageTests.cs
@@ -1,0 +1,255 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+using LabVIEWMcp.Infra;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Infra;
+
+/// <summary>
+/// The icon renderer writes a PNG by hand, so "it produced bytes" proves nothing - a decoder has
+/// to get the pixels back out. These tests walk the chunks, verify every CRC, inflate the IDAT and
+/// read individual pixels, which is the only way to catch a stream that LabVIEW would silently
+/// refuse. No imaging dependency here either, for the same reason there is none in the server.
+/// </summary>
+public sealed class IconImageTests
+{
+    private const int Size = IconImage.Size;
+
+    /// <summary>A decoded image plus what the chunk walk found on the way.</summary>
+    private sealed record Decoded(IconImage.Rgb[] Pixels, List<string> ChunkTypes, int Width, int Height);
+
+    /// <summary>
+    /// Decode an 8-bit truecolour PNG with filter 0 on every scanline - the only kind
+    /// <see cref="IconImage"/> writes. Throws on a bad signature, a bad CRC or an unexpected
+    /// header, so a malformed stream fails the test that produced it.
+    /// </summary>
+    private static Decoded Decode(byte[] png)
+    {
+        ReadOnlySpan<byte> signature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        Assert.True(png.AsSpan(0, 8).SequenceEqual(signature), "PNG signature is wrong");
+
+        var types = new List<string>();
+        var idat = new MemoryStream();
+        int width = 0, height = 0;
+        var at = 8;
+
+        while (at < png.Length)
+        {
+            var length = BinaryPrimitives.ReadInt32BigEndian(png.AsSpan(at, 4));
+            var type = System.Text.Encoding.ASCII.GetString(png, at + 4, 4);
+            var data = png.AsSpan(at + 8, length);
+
+            var declared = BinaryPrimitives.ReadUInt32BigEndian(png.AsSpan(at + 8 + length, 4));
+            Assert.Equal(Crc32(png.AsSpan(at + 4, 4 + length)), declared);
+
+            types.Add(type);
+            switch (type)
+            {
+                case "IHDR":
+                    width = BinaryPrimitives.ReadInt32BigEndian(data[..4]);
+                    height = BinaryPrimitives.ReadInt32BigEndian(data[4..8]);
+                    Assert.Equal(8, data[8]);       // bit depth
+                    Assert.Equal(2, data[9]);       // truecolour
+                    Assert.Equal(0, data[10]);      // deflate
+                    Assert.Equal(0, data[11]);      // filter method 0
+                    Assert.Equal(0, data[12]);      // no interlace
+                    break;
+                case "IDAT":
+                    idat.Write(data);
+                    break;
+            }
+
+            at += 12 + length;
+        }
+
+        Assert.Equal(["IHDR", "IDAT", "IEND"], types);
+
+        idat.Position = 0;
+        using var inflated = new MemoryStream();
+        using (var zlib = new ZLibStream(idat, CompressionMode.Decompress))
+            zlib.CopyTo(inflated);
+
+        var raw = inflated.ToArray();
+        Assert.Equal(height * (1 + width * 3), raw.Length);
+
+        var pixels = new IconImage.Rgb[width * height];
+        for (var y = 0; y < height; y++)
+        {
+            var row = y * (1 + width * 3);
+            Assert.Equal(0, raw[row]);              // filter: none, on every scanline
+            for (var x = 0; x < width; x++)
+            {
+                var p = row + 1 + x * 3;
+                pixels[y * width + x] = new IconImage.Rgb(raw[p], raw[p + 1], raw[p + 2]);
+            }
+        }
+
+        return new Decoded(pixels, types, width, height);
+    }
+
+    private static uint Crc32(ReadOnlySpan<byte> data)
+    {
+        var c = 0xFFFFFFFFu;
+        foreach (var b in data)
+        {
+            c ^= b;
+            for (var k = 0; k < 8; k++)
+                c = (c & 1) != 0 ? 0xEDB88320u ^ (c >> 1) : c >> 1;
+        }
+        return c ^ 0xFFFFFFFFu;
+    }
+
+    private static readonly IconImage.Rgb Blue = new(0x00, 0x5A, 0x9C);
+    private static readonly IconImage.Rgb White = new(0xFF, 0xFF, 0xFF);
+    private static readonly IconImage.Rgb Black = new(0x00, 0x00, 0x00);
+
+    private static byte[] Render(string? l1 = "DAQ", string? l2 = null, string? l3 = null) =>
+        IconImage.Render(l1, l2, l3, Blue, White, Black,
+                         IconImage.ReadableOn(Blue), IconImage.ReadableOn(White));
+
+    private static IconImage.Rgb At(Decoded d, int x, int y) => d.Pixels[y * d.Width + x];
+
+    [Fact]
+    public void Writes_a_decodable_32x32_png()
+    {
+        var decoded = Decode(Render());
+
+        Assert.Equal(32, decoded.Width);
+        Assert.Equal(32, decoded.Height);
+        Assert.Equal(Size * Size, decoded.Pixels.Length);
+    }
+
+    [Fact]
+    public void Frames_the_icon_and_fills_banner_and_body()
+    {
+        var decoded = Decode(Render(l1: null));   // no text: only the fills are under test
+
+        Assert.Equal(Black, At(decoded, 0, 0));            // corners are border
+        Assert.Equal(Black, At(decoded, 31, 31));
+        Assert.Equal(Black, At(decoded, 0, 16));           // left edge
+        Assert.Equal(Black, At(decoded, 31, 16));          // right edge
+
+        Assert.Equal(Blue, At(decoded, 16, 5));            // inside the banner
+        Assert.Equal(Blue, At(decoded, 1, 9));             // banner reaches its last row
+        Assert.Equal(White, At(decoded, 16, 15));          // body below it
+        Assert.Equal(White, At(decoded, 16, 30));
+    }
+
+    [Fact]
+    public void Draws_banner_text_in_the_readable_colour()
+    {
+        var withText = Decode(Render(l1: "DAQ"));
+        var without = Decode(Render(l1: null));
+
+        // On NI blue the readable choice is white, so banner text must appear as white pixels
+        // inside the banner - where the empty render has none.
+        var lit = CountIn(withText, White, 1, 9);
+        Assert.True(lit > 20, $"expected banner glyph pixels, found {lit}");
+        Assert.Equal(0, CountIn(without, White, 1, 9));
+        Assert.Equal(White, IconImage.ReadableOn(Blue));
+        Assert.Equal(Black, IconImage.ReadableOn(White));
+    }
+
+    [Fact]
+    public void Draws_the_two_body_lines_separately()
+    {
+        var one = Decode(Render(l1: "DAQ", l2: "3AI"));
+        var two = Decode(Render(l1: "DAQ", l2: "3AI", l3: "TDMS"));
+
+        Assert.True(CountIn(one, Black, 12, 18) > 10, "line2 did not draw");
+        Assert.Equal(0, CountIn(one, Black, 21, 27));           // line3 absent
+        Assert.True(CountIn(two, Black, 21, 27) > 10, "line3 did not draw");
+    }
+
+    /// <summary>Count pixels of one colour in rows <paramref name="from"/>..<paramref name="to"/>,
+    /// excluding the 1 px border columns so the frame never counts.</summary>
+    private static int CountIn(Decoded d, IconImage.Rgb colour, int from, int to)
+    {
+        var n = 0;
+        for (var y = from; y <= to; y++)
+            for (var x = 1; x < d.Width - 1; x++)
+                if (At(d, x, y) == colour) n++;
+        return n;
+    }
+
+    [Fact]
+    public void Truncates_a_line_that_cannot_fit_rather_than_overflowing()
+    {
+        // Six characters do not fit; the render must stay inside the frame either way.
+        var decoded = Decode(Render(l1: "ABCDEFGH"));
+
+        for (var y = 0; y < Size; y++)
+        {
+            Assert.Equal(Black, At(decoded, 0, y));
+            Assert.Equal(Black, At(decoded, Size - 1, y));
+        }
+    }
+
+    [Theory]
+    [InlineData("005A9C", 0x00, 0x5A, 0x9C)]
+    [InlineData("#FF8000", 0xFF, 0x80, 0x00)]
+    [InlineData("  ffffff  ", 0xFF, 0xFF, 0xFF)]
+    public void Parses_both_colour_spellings(string text, int r, int g, int b)
+    {
+        var parsed = IconImage.ParseColor(text);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(new IconImage.Rgb((byte)r, (byte)g, (byte)b), parsed!.Value);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("12345")]
+    [InlineData("0x005A9C")]
+    [InlineData("blue")]
+    [InlineData("GGHHII")]
+    public void Rejects_a_colour_it_cannot_read(string text) =>
+        Assert.Null(IconImage.ParseColor(text));
+
+    [Fact]
+    public void Reports_characters_the_font_cannot_draw()
+    {
+        Assert.Equal("", IconImage.Unsupported("DAQ 3AI-1.0/2:+#"));
+        Assert.Equal("", IconImage.Unsupported("daq"));         // upper-cased, so drawable
+        Assert.Equal("ÄÖ", IconImage.Unsupported("ÄÖÄ"));       // de-duplicated
+        Assert.Equal("_", IconImage.Unsupported("A_B"));
+    }
+
+    [Theory]
+    [InlineData(0x00, 0x5A, 0x9C, 0x00, 0x66, 0x99)]   // NI blue -> its web-safe neighbour
+    [InlineData(0x00, 0x66, 0x99, 0x00, 0x66, 0x99)]   // already safe: unchanged
+    [InlineData(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)]
+    [InlineData(0x7F, 0x7F, 0x7F, 0x66, 0x66, 0x66)]   // 127 is nearer 102 than 153
+    [InlineData(0xC0, 0x39, 0x2B, 0xCC, 0x33, 0x33)]
+    public void Quantises_the_way_labview_does(int r, int g, int b, int qr, int qg, int qb)
+    {
+        var quantised = IconImage.Quantise(new IconImage.Rgb((byte)r, (byte)g, (byte)b));
+
+        Assert.Equal(new IconImage.Rgb((byte)qr, (byte)qg, (byte)qb), quantised);
+        Assert.True(IconImage.IsWebSafe(quantised), "quantising must land inside the cube");
+    }
+
+    [Fact]
+    public void Recognises_which_colours_survive_a_round_trip()
+    {
+        Assert.True(IconImage.IsWebSafe(new IconImage.Rgb(0x00, 0x66, 0x99)));
+        Assert.True(IconImage.IsWebSafe(new IconImage.Rgb(0x00, 0x00, 0x00)));
+        Assert.False(IconImage.IsWebSafe(new IconImage.Rgb(0x00, 0x5A, 0x9C)));
+        Assert.False(IconImage.IsWebSafe(new IconImage.Rgb(0x01, 0x00, 0x00)));
+    }
+
+    [Fact]
+    public void Renders_every_drawable_character_without_leaving_the_frame()
+    {
+        // A glyph table with a wrong row count would walk off the end of the array; rendering
+        // every character in groups of five is the cheapest way to walk the whole table.
+        const string drawable = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -./:+#";
+        for (var i = 0; i < drawable.Length; i += IconImage.MaxCharsPerLine)
+        {
+            var chunk = drawable.Substring(i, Math.Min(IconImage.MaxCharsPerLine, drawable.Length - i));
+            var decoded = Decode(Render(l1: chunk, l2: chunk, l3: chunk));
+            Assert.Equal(Black, At(decoded, 0, 0));
+            Assert.Equal(Black, At(decoded, Size - 1, Size - 1));
+        }
+    }
+}

--- a/tests/LabVIEWMCP.Tests/Tools/IconToolsTests.cs
+++ b/tests/LabVIEWMCP.Tests/Tools/IconToolsTests.cs
@@ -375,4 +375,132 @@ public sealed class IconToolsTests : IDisposable
         Assert.Equal(new FileInfo(vi).Length, Res.Long(result, "viBytesAfter"));
         Assert.False(Res.Bool(result, "viResaved"));   // the fake LabVIEW never touches it
     }
+
+    // ---- drawing the icon here instead of making the caller produce a PNG ----
+    // Measured motive: an agent drawing the bitmap through PowerShell and System.Drawing cost
+    // 12.5 s of a 455 s generation, plus a whole extra tool call. See docs/aixml-reference.md.
+
+    private static string Warnings(string result) =>
+        string.Join(" ", Res.Arr(result, "warnings").Select(w => w!.GetValue<string>()));
+
+    [Fact]
+    public async Task Draws_the_icon_from_lines_and_sends_that_file_to_labview()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+        var vi = WriteVi();
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            vi, iconImagePath: null, readBackPath: PlantReadBack(), helperViPath: At("helper.vi"),
+            helperAixmlPath: ShippedHelperAixml(), line1: "DAQ", line2: "3AI", line3: "TDMS");
+
+        var drawn = Res.Str(result, "iconImagePath")!;
+        Assert.True(Res.Bool(result, "iconRendered"));
+        Assert.Equal("32x32", Res.Str(result, "iconImageSize"));
+        Assert.True(File.Exists(drawn), $"no icon was written at '{drawn}'");
+
+        // What reaches LabVIEW must be the file that was drawn, not a path that only exists in
+        // the response - this is the one contract the fake can check.
+        var request = server.Service.Last<RunVIAsTopLevelRequest>("RunVIAsTopLevel");
+        Assert.Equal(drawn, request.Inputs["Icon File Path"]);
+        Assert.Equal("", Warnings(result));   // a plain 5-char, 3-line icon warrants no warning
+    }
+
+    [Fact]
+    public async Task A_supplied_file_wins_over_lines_and_says_so()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+        var icon = WritePng("icon.png");
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            WriteVi(), icon, At("readback.png"), At("helper.vi"), ShippedHelperAixml(),
+            line1: "DAQ");
+
+        Assert.False(Res.Bool(result, "iconRendered"));
+        Assert.Equal(icon, Res.Str(result, "iconImagePath"));
+        Assert.Contains("lines were ignored", Warnings(result));
+    }
+
+    [Fact]
+    public async Task Refuses_to_run_with_neither_a_file_nor_a_line()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            WriteVi(), iconImagePath: null, readBackPath: At("readback.png"),
+            helperViPath: At("helper.vi"), helperAixmlPath: ShippedHelperAixml());
+
+        Assert.False(Res.Bool(result, "ok"));
+        Assert.Equal("ArgumentException", Res.Str(result, "errorKind"));
+        Assert.Equal(0, server.Service.CountOf("RunVIAsTopLevel"));
+    }
+
+    [Fact]
+    public async Task Warns_about_a_line_too_long_to_fit_but_still_applies_the_icon()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            WriteVi(), iconImagePath: null, readBackPath: At("readback.png"),
+            helperViPath: At("helper.vi"), helperAixmlPath: ShippedHelperAixml(),
+            line1: "ACQUISITION");
+
+        Assert.True(Res.Bool(result, "iconRendered"));
+        Assert.Contains("Only the first 5", Warnings(result));
+        Assert.Contains("'ACQUI'", Warnings(result));
+        Assert.Equal(1, server.Service.CountOf("RunVIAsTopLevel"));
+    }
+
+    [Fact]
+    public async Task Warns_about_an_undrawable_character_and_about_a_bad_colour()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            WriteVi(), iconImagePath: null, readBackPath: At("readback.png"),
+            helperViPath: At("helper.vi"), helperAixmlPath: ShippedHelperAixml(),
+            line1: "A_B", bannerColor: "octarine");
+
+        var warnings = Warnings(result);
+        Assert.Contains("cannot draw", warnings);
+        Assert.Contains("'_'", warnings);
+        Assert.Contains("not RRGGBB", warnings);
+        Assert.Contains("006699", warnings);          // names the fallback it actually used
+        Assert.True(Res.Bool(result, "iconRendered"));
+    }
+
+    [Fact]
+    public async Task Says_what_labview_will_do_to_a_colour_outside_the_web_safe_cube()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            WriteVi(), iconImagePath: null, readBackPath: PlantReadBack(),
+            helperViPath: At("helper.vi"), helperAixmlPath: ShippedHelperAixml(),
+            line1: "DAQ", bannerColor: "005A9C");   // real NI blue: not web-safe
+
+        var warnings = Warnings(result);
+        Assert.Contains("not web-safe", warnings);
+        Assert.Contains("005A9C", warnings);
+        Assert.Contains("006699", warnings);          // what it will read back as
+        Assert.True(Res.Bool(result, "iconRendered"));
+    }
+
+    [Fact]
+    public async Task The_default_colours_are_web_safe_so_nothing_is_warned_about()
+    {
+        await using var server = await LvaiTestServer.StartAsync();
+        server.Service.ViFileContent = "generated helper";
+
+        var result = await new IconTools(server.Connection).SetViIconAsync(
+            WriteVi(), iconImagePath: null, readBackPath: PlantReadBack(),
+            helperViPath: At("helper.vi"), helperAixmlPath: ShippedHelperAixml(), line1: "DAQ");
+
+        Assert.Equal("", Warnings(result));
+    }
 }


### PR DESCRIPTION
The icon was the measured cost, not the mechanism. Profiling a whole VI generation (41 tool calls, 455 s) put it at 21.1 s, of which only 8.6 s reached VI Server - the rest was an agent composing a PowerShell call to draw the PNG through System.Drawing. Across four generation runs the new one-call path measures 5.0-6.2 s.

The default banner is 006699, the web-safe neighbour of NI blue, because LabVIEW quantises a stored icon to the web-safe cube. That makes the PNG written and the icon read back the same image - verified at 0 of 1024 pixels differing.

Three documented rules were contradicted by measurement and corrected:

- maxin wires a For Loop's N. The reference claimed nothing did and that auto-indexing was the only way, which pushed generations into building a literal array or a While-loop counter. Confirmed against NI's own export of Flush Written TDMS Data.vi; a later generation adopted it.
- mode="index" works on an Out tunnel, not only on In tunnels.
- lvai_connector_pane prints six style-guide entries, not four. The dropped "more inputs" row is why a second input landed on conIdx 1 three runs in a row - on pattern 4833 the left edge is 0, 5, 7, 9. After the fix one run placed it correctly first try, using two pane calls instead of three.

The plugin/agents mirrors still carried the disproven "a generated VI always gets pattern 4815, so this map is a constant" - the rule that produced the pane the user rejected on sight. They are hand-maintained copies and drift.