### PR TITLE
Add AIXML skeletons and symbolic uids

### DIFF
--- a/.claude/agents/labview-vi-editor.md
+++ b/.claude/agents/labview-vi-editor.md
@@ -110,6 +110,13 @@ So when the VI has one, validate the **untouched** export before promising anyth
   breaks the guide is a defect worth naming in the report and correcting, since `conIdx` is one
   attribute per terminal and costs nothing to change. Detail in `lvai_aixml_reference` §2, "The
   connector pane".
+- **`uid` may be a symbol rather than a number** — `uid="read"`, `outputs="value:read.data"`. The
+  server assigns numbers before LabVIEW sees the file, and `symbolicUids` in the response maps each
+  one back. In an edit this matters most for elements you ADD to an exported diagram: name them
+  instead of hunting for numbers that are still free. Existing numbers in the export stay as they
+  are — the two spellings mix in one file, and a file with no symbol is not rewritten at all.
+  `scripts/aixml-skeletons/` holds validated shapes worth copying from, and its header says what in
+  it is a station-specific measurement rather than a fact.
 - **Preserve what you are not changing.** Start from the exported AIXML and edit it. Do not
   re-author the VI from scratch because that felt tidier — every `uid` you needlessly change is
   a diff the user has to review.

--- a/.claude/agents/labview-vi-generator.md
+++ b/.claude/agents/labview-vi-generator.md
@@ -121,6 +121,24 @@ it an icon.
   corner. It validated, it ran, and the user rejected it on sight. Do not copy indices out of an NI
   VI either: those use patterns of their own. Both full maps in `lvai_aixml_reference` §2, "The
   connector pane".
+- **Start from a skeleton where one fits, and name your elements instead of numbering them.**
+  `scripts/aixml-skeletons/` holds complete, validated AIXML for shapes that are easy to get wrong.
+  `accumulate-across-a-loop.xml` carries the `maxin` For Loop, the shift-register accumulator and
+  the seed/append/keep case pair without which the inner indexing loop runs zero times on iteration
+  0 and the accumulator stays empty for the whole run. It answers a different question from
+  `lvai_example_index`: that one says whether NI already built this diagram, this one says how the
+  shape is **spelled**.
+
+  `uid` may be a **symbol** — `uid="read"`, `outputs="value:read.data"` — and the server assigns
+  numbers before LabVIEW sees the file. Measured: one generation spent a single 47 s turn planning
+  uid numbers, which is notation overhead and nothing else. Symbols also make copying out of a
+  skeleton free, because there is nothing to renumber.
+
+  **A skeleton does not replace the lookups that produced it — it replaces the typing.** It carries
+  no `conIdx`, because that is a station setting: still call `lvai_connector_pane`. Its polymorphic
+  `instance=` is a measurement with a date in the file header: still confirm it with
+  `lvai_vi_terminals`. A frozen measurement is exactly how "a generated VI always gets pattern
+  4815" came to ship a wrongly-populated pane.
 - **Write AIXML to a file with the `Write` tool.** Never build it in a shell command or a string
   literal: the `\3A` and `\5C` escapes get eaten and the failure arrives disguised as an XML parse
   error, which sends you looking in the wrong place.

--- a/docs/aixml-reference.md
+++ b/docs/aixml-reference.md
@@ -2246,6 +2246,63 @@ Consequences for authoring:
   read at all, verify out of band — write the result to a file and inspect that, rather than
   trusting an empty answer either way.
 
+### Naming elements instead of numbering them
+
+`uid` may be a **symbol** rather than a number — `uid="read"`, `outputs="value:read.data"` — and the
+MCP server assigns the numbers immediately before the file goes to LabVIEW, which never sees a
+symbol. `lvai_validate_aixml`, `lvai_convert_aixml_to_vi` and `lvai_apply_aixml_to_vi` all accept
+it.
+
+The reason is measured, not aesthetic: profiling one whole generation put a single turn of **47 s**
+on "planning out the unique uids", pure notation overhead with no bearing on what the diagram does.
+The format needs numbers; the author does not need to keep a numbering scheme in their head while
+deciding what to wire to what.
+
+A symbol starts with a letter or underscore and contains letters, digits, underscore or hyphen.
+Dots and colons are reserved — they separate a uid from a terminal name. `root` keeps its meaning
+and is never treated as a symbol. Numbers and symbols may be mixed in one file.
+
+What the response tells you when symbols were used: `symbolicUids` maps each symbol to the number
+it was given, and `aiXmlSentToLabview` is the numbered file LabVIEW actually read. Messages naming
+a `uid` are translated back; a bare number is deliberately **not**, because turning `-200220` or
+`Error 1357` into a symbol name would be a worse failure than leaving one number untranslated.
+
+Three properties this was built to keep, because a mistake here yields a VI that validates, runs and
+is wired wrongly rather than an error:
+
+- **A file with no symbol is not rewritten at all** — the original path goes to LabVIEW. The same
+  applies to anything unreadable: a missing file, a locked one, malformed XML. That inertness is
+  not a nicety; adding the feature without it broke 13 existing tests at once, which pass paths that
+  were never created and relied on LabVIEW to say so.
+- **The mapping is injective**, one number per distinct symbol.
+- **Numbering starts above the highest number already in the file**, so a symbol can never take a
+  number the author used.
+
+### Starting from a skeleton
+
+`scripts/aixml-skeletons/` holds complete, validated AIXML whose purpose is to be read and copied
+from. It answers a different question from `lvai_example_index`: that one says *has NI already built
+this diagram*, this one says *how is this shape spelled in AIXML*. Skeletons use symbolic uids, so
+elements can be lifted out of one and dropped into your own file without renumbering.
+
+`accumulate-across-a-loop.xml` carries the shape that has been got wrong most often here: a For Loop
+given its `N` by `maxin`, an accumulator on a shift register seeded from an empty-array constant,
+and the seed / append / keep case pair without which the inner indexing loop runs zero times on
+iteration 0 and the accumulator stays empty for the whole run.
+
+**A skeleton is a frozen measurement, and this repository has already shipped one that stopped being
+true.** "A generated VI always gets pattern 4815, so this map is a constant" was correct when
+measured and produced a wrongly-populated connector pane on a station configured differently. So:
+
+- skeletons carry **no `conIdx`** — that is a station setting, and `lvai_connector_pane` with no
+  argument is the only honest source;
+- a polymorphic `instance=` in a skeleton is what was measured on the station named in its header,
+  and still wants confirming with `lvai_vi_terminals`;
+- each file states the date, the LabVIEW version and the station it was validated on, so a reader
+  can see how old the claim is.
+
+Copying a skeleton must not replace the lookups that produced it. It replaces the *typing*.
+
 ## 11. Known failure modes
 
 | Symptom | Cause |
@@ -2265,8 +2322,9 @@ Consequences for authoring:
 | **The VI runs, reports no error, and computes the WRONG ANSWER** | **`value="TRUE"` on a boolean is silently read as `false`.** The worst member of the family, because the other two leave something visibly missing and this one leaves a working VI that is simply wrong. Measured, four spellings in one probe VI, all validating with `errorCode 0` and all generating cleanly: <br>`value="true"` → **TRUE** — the only one that works<br>`value="TRUE"` → false `value="True"` → false `value="1"` → false<br>It cost a generated CSV loader a whole debugging round: its `transpose?` constant read `TRUE`, so the file was read untransposed, and the VI returned 1 sample with `dt = 1.0` instead of 8 with `dt = 0.1` — no error anywhere. It was caught only by comparing the numbers against the source file. **Emit exactly lowercase `true`/`false`, which is what an export writes**, and check a boolean constant's effect against real data rather than against `errorCode`. |
 | **A VI in memory CAN be evicted — via the active project** | **Read this row's ending first: there is a working recipe**, in `vi-server-reference.md` under "Unloading a VI so its path can be regenerated". Reach the IDE's application through `{LV.Application}` → `Project\3AActive Project` → `{LV.Project}` → `Application`, open the VI reference *there*, and write `Front Panel Window\3AState` = `Closed`. Measured A/B: `1357` before, `errorCode 0` after. The rest of this row is the long road that found it, kept because every step of it is a thing that does **not** work. The fallback rule remains sound when no project is active: **generate each iteration under a fresh name, and do not `lvai_open_file` a VI you still intend to regenerate.** Measured, in one helper run that itself reported no error: writing `Front Panel Window\3AOpen` **and** `Block Diagram Window\3AOpen` to `False`, then `FP.Set Close If Lonely`, then `Close Reference` — and the regeneration still failed with 1357. The catalogue carries no unload or remove-from-memory method at all across its 3 078 entries. Earlier advice here said "or make LabVIEW release the VI"; that is not achievable through this interface. Closing the VI in the IDE by hand, or restarting LabVIEW, is the reset. **Re-measured on a freshly restarted machine, with the one remaining explanation tested and killed:** the idea that closing the window *modifies* the VI and that a modified VI cannot be unloaded. Reading `Modifications\3AUser Changes` before the close, after it, and after a `Save\3AInstrument` gave **clean, clean, clean** — unsaved changes were never what held it. Same run, no error anywhere in it, regeneration still 1357. What every one of these attempts shared, and what took an evening to see: they all ran in the **addon's** application instance, where the VI's windows do not exist. That is why closing them changed nothing — see the recipe named at the top of this row. **The escape hatch is real, and measured:** a person closing the VI in the IDE by hand frees the path immediately — the very next `ConvertAIXMLToVI` on it returned `errorCode 0`. So when you are stuck on a path, the fix is a human closing that window, not another property write. **Opening the VI inside a project changes nothing** — tested, because "we never opened it in a project, which would be the normal case" is the obvious objection. A hand-written `.lvproj` (§2 of the lvproj reference), the VI generated beside it and opened with both the VI *and* project pairs, `describe_project` confirming it loaded as a real member with `missingFiles: []`: regeneration still `1357`. Project membership is not what holds the file. |
 | `Error 42 ... Generic error` from `ApplyAIXMLToVI` | **Not a payload problem — see §14.** The RPC itself works; it is gated on a per-VI attachment a third-party client cannot obtain. |
-| `Error 42 ... Generic error` from **`ValidateAIXML`** | A different cause with the same useless message: **an XML comment in the document.** `<!-- … -->` anywhere inside makes validation fail with `Error 42 occurred at LV AI Core.lvlibp:VI generator.vi`, `(Hex 0x2A) Generic error` — no line, no column, no element. Measured 2026-08-13 by deleting the comment and changing nothing else: the same file then validated `errorCode 0`. It misleads badly because the well-formedness errors this RPC *does* report are precise to the column (`Line 5, Column 308, missing required attribute 'outputs'`), so a bare generic error reads as a deep structural fault and invites rewriting the diagram. Put notes in a `FreeLabel`, the `comment` attribute, or a `description` — see "Practical consequence for comments". |
-| **Every `lvai_*` call stops answering after you ran a generated VI** | The VI you generated is showing a MODAL DIALOG, and LabVIEW answers nothing until a human dismisses it. The known cause is the missing-subVI prompt, but there is a second, entirely independent one that fires on ordinary input: **a palette VI whose path input is named `… (dialog if empty)` opens a file dialog when handed an empty path.** `Read Delimited Spreadsheet.vi` has exactly that — `file path (dialog if empty)` — so a generated VI that passes an unvalidated file name through it wedges the session on the emptiest possible input. The terminal *name* is the only warning. Guard it on the diagram: compare the string against `""` and `Select` a placeholder path, which turns the hang into an ordinary file error. Measured: with the guard, an empty name returns in under 40 ms and no dialog appears. **Which error code you get depends on the placeholder you chose** — an absolute one that does not exist gives `7` (file not found), a bare relative name gives `1430` (path is empty or relative). Both are fine; just do not copy a code out of this table into a VI description without measuring your own. |
+| `Error 42 ... Generic error` from **`ValidateAIXML`** | Cause unsettled, and the XML-comment explanation this row used to give is **contradicted by a later measurement — do not act on it.** It said `<!-- … -->` anywhere in the document fails validation with `Error 42`, measured 2026-08-13 by deleting the comment and changing nothing else. On **2026-08-14** `scripts/aixml-skeletons/accumulate-across-a-loop.xml` validated `errorCode 0` and generated a real VI while carrying **two** comments — a long header before the root element and one *inside* the `<VI>` element — verified by reading the exact file handed to LabVIEW, not the source. Something else caused the 2026-08-13 failure, or the behaviour changed with a LabVIEW or addon update; the two measurements do not distinguish those. What survives is the useful half: this message carries no line, no column and no element, while the well-formedness errors the RPC *does* report are precise to the column (`Line 5, Column 308, missing required attribute 'outputs'`), so a bare generic error reads as a deep structural fault and invites rewriting a diagram that is fine. Bisect the file rather than trusting any single suspect. |
+| **Every `lvai_*` call stops answering after you ran a generated VI** | The VI you generated is showing a MODAL DIALOG, and LabVIEW answers nothing until a human dismisses it. The known cause is the missing-subVI prompt, but there is a second, entirely independent one that fires on ordinary input: **a palette VI whose path input is named `… (dialog if empty)` opens a file dialog when handed an empty path.** `Read Delimited Spreadsheet.vi` has exactly that — `file path (dialog if empty)` — so a generated VI that passes an unvalidated file name through it wedges the session on the emptiest possible input. The terminal *name* is the only warning. Guard it on the diagram: compare the string against `""` and `Select` a placeholder path, which turns the hang into an ordinary file error. Measured: with the guard, an empty name returns in under 40 ms and no dialog appears. **Which error code you get depends on the placeholder you chose** — an absolute one that does not exist gives `7` (file not found), a bare relative name gives `1430` (path is empty or relative). Both are fine; just do not copy a code out of this table into a VI description without measuring your own. **Those two codes were measured on a READ, and they do not transfer to a CREATE — see the row below.** |
+| **A relative placeholder path silently writes into the LabVIEW installation directory** | The guard above, applied to a node that *creates*. `TDMS Open` with `operation` = `create or replace` does **not** reject a bare relative name: it resolves it against LabVIEW's working directory and creates the file there — measured in a generation run on 2026-08-14, which left `DaqReadAndTDMS_no_path_given.tdms` and its `_index` inside `C:\Program Files (x86)\National Instruments\LabVIEW 2026\` while the VI's own description claimed a file error had been returned. The `1430` in the row above came from `Read Delimited Spreadsheet.vi`, a **read**, where a relative path is invalid; for a create it is perfectly valid and gets created. **A file-path error code measured on one direction says nothing about the other.** Two consequences. If you use a placeholder at all, make it **absolute**. And check first whether the node needs a guard: the terminal name is the tell — `TDMS Open` takes `file path`, not `file path (use dialog)` or `(dialog if empty)`, so it cannot open a dialog, and an empty path returns error `118` in 48 ms on its own. The guard was protecting against something that node does not do. **Confirmed independently the same day with a purpose-built two-node probe** (`TDMS Open` → `TDMS Close`, create-or-replace, path taken as a string and converted on the diagram, error cluster unbundled): the bare relative name `lvai_probe_relative.tdms` returned **`status false`, `code 0`** — success, not an error — and the file plus its `_index` were then found at `C:\Program Files (x86)\National Instruments\LabVIEW 2026\`; the same probe with an **empty** path returned **`code 118` in 25 ms**, with `file path out` reading `<Not A Path>` and no dialog. Two runs of one VI settle both halves. |
 
 ## 12. This document has been tested
 

--- a/plugin/agents/labview-vi-editor.md
+++ b/plugin/agents/labview-vi-editor.md
@@ -108,6 +108,13 @@ So when the VI has one, validate the **untouched** export before promising anyth
   breaks the guide is a defect worth naming in the report and correcting, since `conIdx` is one
   attribute per terminal and costs nothing to change. Detail in `lvai_aixml_reference` §2, "The
   connector pane".
+- **`uid` may be a symbol rather than a number** — `uid="read"`, `outputs="value:read.data"`. The
+  server assigns numbers before LabVIEW sees the file, and `symbolicUids` in the response maps each
+  one back. In an edit this matters most for elements you ADD to an exported diagram: name them
+  instead of hunting for numbers that are still free. Existing numbers in the export stay as they
+  are — the two spellings mix in one file, and a file with no symbol is not rewritten at all.
+  `scripts/aixml-skeletons/` holds validated shapes worth copying from, and its header says what in
+  it is a station-specific measurement rather than a fact.
 - **Preserve what you are not changing.** Start from the exported AIXML and edit it. Do not
   re-author the VI from scratch because that felt tidier — every `uid` you needlessly change is
   a diff the user has to review.

--- a/plugin/agents/labview-vi-generator.md
+++ b/plugin/agents/labview-vi-generator.md
@@ -100,6 +100,24 @@ it an icon.
   it ran, and the user rejected it on sight. The pattern is a station setting, not a constant. Do not
   copy indices out of an NI VI either: those use patterns of their own. Both full maps in
   `lvai_aixml_reference` §2, "The connector pane".
+- **Start from a skeleton where one fits, and name your elements instead of numbering them.**
+  `scripts/aixml-skeletons/` holds complete, validated AIXML for shapes that are easy to get wrong.
+  `accumulate-across-a-loop.xml` carries the `maxin` For Loop, the shift-register accumulator and
+  the seed/append/keep case pair without which the inner indexing loop runs zero times on iteration
+  0 and the accumulator stays empty for the whole run. It answers a different question from
+  `lvai_example_index`: that one says whether NI already built this diagram, this one says how the
+  shape is **spelled**.
+
+  `uid` may be a **symbol** — `uid="read"`, `outputs="value:read.data"` — and the server assigns
+  numbers before LabVIEW sees the file. Measured: one generation spent a single 47 s turn planning
+  uid numbers, which is notation overhead and nothing else. Symbols also make copying out of a
+  skeleton free, because there is nothing to renumber.
+
+  **A skeleton does not replace the lookups that produced it — it replaces the typing.** It carries
+  no `conIdx`, because that is a station setting: still call `lvai_connector_pane`. Its polymorphic
+  `instance=` is a measurement with a date in the file header: still confirm it with
+  `lvai_vi_terminals`. A frozen measurement is exactly how "a generated VI always gets pattern
+  4815" came to ship a wrongly-populated pane.
 - **Write AIXML to a file with the `Write` tool.** Never build it in a shell command or a string
   literal: the `\3A` and `\5C` escapes get eaten and the failure arrives disguised as an XML parse
   error, which sends you looking in the wrong place.

--- a/scripts/aixml-skeletons/accumulate-across-a-loop.xml
+++ b/scripts/aixml-skeletons/accumulate-across-a-loop.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SKELETON - accumulate one block per iteration instead of keeping only the last.
+
+  Shows three shapes that were each got wrong at least once and re-derived three times:
+
+    * a For Loop given its N by `maxin` (here `maxin="n.value"` from an int32 constant),
+      not by indexing a literal array and not by a While Loop with a counter;
+    * an accumulator on a shift register, seeded from an EMPTY array constant;
+    * the seed / append / keep case pair that makes that accumulator work at all.
+
+  WHY THE CASE PAIR IS NOT OPTIONAL. The inner For Loop auto-indexes the accumulator against
+  the new block. On iteration 0 the accumulator is empty, so it runs min(0, N) = 0 times and
+  the accumulator stays empty FOREVER. Nothing reports this: it validates, it runs, and the
+  output is an empty array that looks exactly like a device error. Hence the inner case,
+  selected on "is the accumulator empty", which seeds instead of appending. The outer case,
+  selected on "is the new block empty", keeps what has already been accumulated when a late
+  read fails - without it the same zero-iteration arithmetic wipes the run's data.
+
+  WHAT YOU MUST NOT COPY FROM HERE
+
+    * There are no `conIdx` attributes, deliberately. Which index is which slot depends on the
+      pane pattern, which is a station setting (`DefaultConPane` in LabVIEW.ini). Call
+      `lvai_connector_pane` with no argument and take the numbers from there.
+    * `instance="WDT Append Waveforms DBL.vi"` is the polymorphic instance measured on the
+      station below. Confirm it with `lvai_vi_terminals` rather than trusting this file: a
+      skeleton is a frozen measurement, and this repository has already shipped one that
+      stopped being true ("a generated VI always gets pattern 4815").
+
+  Uses SYMBOLIC uids - the server numbers them before LabVIEW sees the file, so elements can
+  be copied out of here into your own AIXML without renumbering anything.
+
+  WHAT "VALIDATED" COVERS HERE, exactly:
+
+    * ValidateAIXML returns errorCode 0, and ConvertAIXMLToVI produces a real VI (3 166 bytes).
+      Measured 2026-08-14 on LabVIEW 2026, DefaultConPane=4833.
+    * The accumulation ARITHMETIC is NOT re-proven by this file. `block` is an array of
+      waveforms, and the run tools can only set string inputs, so running this skeleton feeds
+      it an empty block and every iteration takes the "keep" branch. The shape is copied from
+      the diagram of C:\temp\DaqReadAndTDMS.vi, where it WAS verified behaviourally at
+      3 channels x 500 samples through a harness that built synthetic waveforms on the diagram.
+      So the arithmetic is inherited evidence, not a measurement of this file.
+
+  Worth adding when someone next touches this: a sibling self-test that builds a synthetic block
+  on the diagram, so the skeleton proves its own central claim instead of inheriting it.
+-->
+<VI _name="accumulate-across-a-loop.vi"
+    description="Skeleton. Appends one block per iteration to an accumulator carried on a shift register\2C so the whole run is returned rather than the last block. Not meant to be shipped\3A copy the shapes\2C not the file.">
+
+  <Control _name="block" connection="required"
+           description="One block\2C as a real loop would receive it from an acquisition node."
+           outputs="value:block.value" type="array{doublewaveform.Waveform}"
+           uid="block" uid_parent="root" value=""/>
+
+  <Constant _name="blocks to accumulate" outputs="value:n.value" type="int32"
+            uid="n" uid_parent="root" value="5"/>
+
+  <Constant _name="empty accumulator" outputs="value:seed.value"
+            type="array{doublewaveform.Waveform}" uid="seed" uid_parent="root" value="[]"/>
+
+  <Structure _name="For Loop" count="" maxin="n.value" maxout="" uid="loop" uid_parent="root">
+
+    <Tunnel _id="In1" inputs="value:block.value" outputs="value:blockIn.value"
+            uid="blockIn" uid_parent="loop"/>
+
+    <ShiftReg uid="acc" uid_parent="loop">
+      <Left  inputs="value:seed.value"     outputs="value:accL.value" uid="accL" uid_parent="acc"/>
+      <Right inputs="value:outerOut.value" outputs="value:accR.value" uid="accR" uid_parent="acc"/>
+    </ShiftReg>
+
+    <Node _name="Empty Array?" inputs="array:accL.value"
+          outputs="empty?:accEmpty.empty?" uid="accEmpty" uid_parent="loop"/>
+    <Node _name="Empty Array?" inputs="array:blockIn.value"
+          outputs="empty?:blockEmpty.empty?" uid="blockEmpty" uid_parent="loop"/>
+
+    <Structure _name="Case Structure" selectin="blockEmpty.empty?" uid="outer" uid_parent="loop">
+      <Tunnel _id="In1" inputs="value:accL.value"          uid="oIn1" uid_parent="outer"/>
+      <Tunnel _id="In2" inputs="value:blockIn.value"       uid="oIn2" uid_parent="outer"/>
+      <Tunnel _id="In3" inputs="value:accEmpty.empty?"     uid="oIn3" uid_parent="outer"/>
+
+      <CaseFrame selector="True" selectout="" uid="keep" uid_parent="outer">
+        <FreeLabel comment="No data in this block \2D keep what has already been accumulated."
+                   uid="keepLabel" uid_parent="keep"/>
+        <Tunnel _id="In1"  outputs="value:kIn1.value" uid="kIn1" uid_parent="keep"/>
+        <Tunnel _id="In2"  outputs="value:"           uid="kIn2" uid_parent="keep"/>
+        <Tunnel _id="In3"  outputs="value:"           uid="kIn3" uid_parent="keep"/>
+        <Tunnel _id="Out1" inputs="value:kIn1.value"  uid="kOut" uid_parent="keep"/>
+      </CaseFrame>
+
+      <CaseFrame selector="False" selectout="" uid="work" uid_parent="outer">
+        <Tunnel _id="In1" outputs="value:wIn1.value" uid="wIn1" uid_parent="work"/>
+        <Tunnel _id="In2" outputs="value:wIn2.value" uid="wIn2" uid_parent="work"/>
+        <Tunnel _id="In3" outputs="value:wIn3.value" uid="wIn3" uid_parent="work"/>
+
+        <Structure _name="Case Structure" selectin="wIn3.value" uid="inner" uid_parent="work">
+          <Tunnel _id="In1" inputs="value:wIn1.value" uid="iIn1" uid_parent="inner"/>
+          <Tunnel _id="In2" inputs="value:wIn2.value" uid="iIn2" uid_parent="inner"/>
+
+          <CaseFrame selector="True" selectout="" uid="seedFrame" uid_parent="inner">
+            <FreeLabel comment="Accumulator still empty \2D take this block as the seed."
+                       uid="seedLabel" uid_parent="seedFrame"/>
+            <Tunnel _id="In1"  outputs="value:"           uid="sIn1" uid_parent="seedFrame"/>
+            <Tunnel _id="In2"  outputs="value:sIn2.value" uid="sIn2" uid_parent="seedFrame"/>
+            <Tunnel _id="Out1" inputs="value:sIn2.value"  uid="sOut" uid_parent="seedFrame"/>
+          </CaseFrame>
+
+          <CaseFrame selector="False" selectout="" uid="appendFrame" uid_parent="inner">
+            <Tunnel _id="In1" outputs="value:aIn1.value" uid="aIn1" uid_parent="appendFrame"/>
+            <Tunnel _id="In2" outputs="value:aIn2.value" uid="aIn2" uid_parent="appendFrame"/>
+
+            <Structure _name="For Loop" count="" maxin="" maxout=""
+                       uid="perChannel" uid_parent="appendFrame">
+              <Tunnel _id="In1" inputs="value:aIn1.value" mode="index"
+                      outputs="value:pIn1.value" uid="pIn1" uid_parent="perChannel"/>
+              <Tunnel _id="In2" inputs="value:aIn2.value" mode="index"
+                      outputs="value:pIn2.value" uid="pIn2" uid_parent="perChannel"/>
+              <Call adapt="true"
+                    inputs="waveform A:pIn1.value,waveform B:pIn2.value,error in (no error):"
+                    instance="WDT Append Waveforms DBL.vi"
+                    outputs="waveform out:appendCall.waveform out,error out:"
+                    target="Append Waveforms.vi" uid="appendCall" uid_parent="perChannel"/>
+              <Tunnel _id="Out1" inputs="value:appendCall.waveform out" mode="index"
+                      outputs="value:pOut.value" uid="pOut" uid_parent="perChannel"/>
+            </Structure>
+
+            <Tunnel _id="Out1" inputs="value:pOut.value" uid="aOut" uid_parent="appendFrame"/>
+          </CaseFrame>
+
+          <Tunnel _id="Out1" outputs="value:iOut.value" uid="iOut" uid_parent="inner"/>
+        </Structure>
+
+        <Tunnel _id="Out1" inputs="value:iOut.value" uid="wOut" uid_parent="work"/>
+      </CaseFrame>
+
+      <Tunnel _id="Out1" outputs="value:outerOut.value" uid="outerOut" uid_parent="outer"/>
+    </Structure>
+  </Structure>
+
+  <!-- value="" is REQUIRED on an Indicator, not only on a Control. Leaving it off fails
+       validation with `missing required attribute 'value'` and a line number, which is clear
+       enough once you know that Indicator and Control share the schema. -->
+  <Indicator _name="accumulated" connection="recommended"
+             description="Every block appended per channel\2C not just the last one."
+             inputs="value:accR.value" type="array{doublewaveform.Waveform}"
+             uid="out" uid_parent="root" value=""/>
+</VI>

--- a/scripts/generation_scorecard.py
+++ b/scripts/generation_scorecard.py
@@ -1,0 +1,295 @@
+"""Score one VI-generation run: where its wall clock went, and how good the result was.
+
+    python scripts/generation_scorecard.py <agent-transcript.jsonl>
+
+The transcript is the subagent's own log, written by the client under
+`~/.claude/projects/<project>/<session>/subagents/agent-<id>.jsonl`. Reading it costs
+nothing and adds no round trips, which is the point: asking the agent to time itself
+would add exactly the turns being measured.
+
+WHY THE QUALITY HALF EXISTS. Every optimisation applied to this generator reduces time,
+and time is what gets measured - so a quality regression is invisible to the loop that
+drives the work. It has already happened once: the fastest of four profiled runs (450 s)
+was also the one that checked its accumulator only structurally instead of measuring it,
+and that was noticed by reading the report, not by any number. These four signals are the
+ones a transcript can answer objectively. They do not measure whether the VI is *good*;
+they measure whether the agent's own checks passed on the first attempt and how much
+rework it needed.
+
+TWO MEASUREMENT MISTAKES ARE BAKED IN HERE, both made and corrected during the session
+that produced this script:
+
+  1. Idle gaps must leave the MODEL sum, not just the span. A background agent gets
+     descheduled; charging those gaps to generation produced a profile reading
+     "model turns 133.3 %" with negative unattributed time. A percentage over 100 is the
+     tell - never report a profile showing one.
+  2. Bucket by what a call DID, not by which tool ran it. A first version charged every
+     Bash and PowerShell call to the icon phase and reported 48 s where the truth was
+     21 s; three of those calls were sed edits to the AIXML. This script therefore refuses
+     to classify shell calls at all and prints their command heads instead, so the reader
+     classifies them.
+"""
+import collections
+import json
+import re
+import sys
+from datetime import datetime
+
+# A gap longer than this is the agent waiting to be resumed, not thinking.
+IDLE_SECONDS = 60.0
+
+PHASES = {
+    "research": """
+        example_index palette_index aixml_reference vi_terminals
+        lvproj_reference vi_server_reference lvlib_reference dqmh_reference
+        convert_vi_to_aixml convert_vis_to_aixml status ensure_labview
+        describe_vi filter_example_search_candidates Glob Grep Read
+    """.split(),
+    "authoring": """
+        Write Edit validate_aixml convert_aixml_to_vi apply_aixml_to_vi
+    """.split(),
+    "verify": """
+        run_vi_and_read_values run_vi_as_top_level connector_pane
+        describe_project open_file close_vi
+    """.split(),
+    "icon": ["set_vi_icon"],
+}
+PHASE_OF = {tool: phase for phase, tools in PHASES.items() for tool in tools}
+
+# Deliberately unclassified: what a shell call was for cannot be read off its name.
+SHELL = {"Bash", "PowerShell"}
+
+
+def ts(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def blocks(entry, kind):
+    content = (entry.get("message") or {}).get("content")
+    if not isinstance(content, list):
+        return []
+    return [b for b in content if isinstance(b, dict) and b.get("type") == kind]
+
+
+def result_text(block):
+    """A tool_result's payload, whether it arrived as a string or as text blocks."""
+    content = block.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def short(name):
+    """
+    ONE canonical short name, used by every lookup in this file: `validate_aixml`.
+
+    Both halves of this script key on tool names, and they briefly disagreed about whether the
+    `lvai_` prefix was part of the name. The phase table then reported 39 of 54 calls as
+    'unclassified'; fixing that by keeping the prefix silently broke the quality section into
+    reporting "no validate call" for a run with eight of them. Two conventions is the bug - hence
+    one function, stripping everything, used everywhere.
+    """
+    return name.replace("mcp__labview__", "").removeprefix("lvai_")
+
+
+def load(path):
+    entries = []
+    for line in open(path, encoding="utf-8", errors="replace"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        if entry.get("timestamp"):
+            entries.append(entry)
+    entries.sort(key=lambda e: ts(e["timestamp"]))
+    return entries
+
+
+class Call:
+    """One tool call, joined to its result."""
+
+    def __init__(self, name, started, lead, inputs):
+        self.name = name
+        self.started = started
+        self.lead = lead          # model time spent producing the call
+        self.inputs = inputs
+        self.duration = 0.0
+        self.result = ""
+
+
+def join_calls(entries):
+    """Pair every tool_use with its tool_result, carrying the model time that preceded it."""
+    pending, previous = {}, None
+    for entry in entries:
+        uses = blocks(entry, "tool_use")
+        if uses:
+            gap = 0.0
+            if previous is not None:
+                gap = (ts(entry["timestamp"]) - ts(previous["timestamp"])).total_seconds()
+            # An idle wait is not authoring time - see the module docstring.
+            if gap > IDLE_SECONDS or gap < 0:
+                gap = 0.0
+            for use in uses:
+                pending[use.get("id")] = Call(
+                    use.get("name", "?"), ts(entry["timestamp"]), gap / len(uses),
+                    use.get("input") or {})
+        previous = entry
+
+    calls = []
+    for entry in entries:
+        for block in blocks(entry, "tool_result"):
+            call = pending.get(block.get("tool_use_id"))
+            if call is None:
+                continue
+            call.duration = max(0.0, (ts(entry["timestamp"]) - call.started).total_seconds())
+            call.result = result_text(block)
+            calls.append(call)
+    return calls
+
+
+def timing(entries, calls):
+    span = (ts(entries[-1]["timestamp"]) - ts(entries[0]["timestamp"])).total_seconds()
+    idle = sum(
+        gap for gap in (
+            (ts(b["timestamp"]) - ts(a["timestamp"])).total_seconds()
+            for a, b in zip(entries, entries[1:])
+        ) if gap > IDLE_SECONDS
+    )
+    active = span - idle
+
+    # Text-only turns: the model thinking or writing without calling anything. The test must be
+    # on THIS entry, not the previous one. Testing the previous entry counted the lead time of
+    # tool-carrying turns here as well as in `lead_total`, and the three lines then summed to
+    # 126 % of active time - which is the tell this module's docstring warns about, caught by it.
+    model, previous = 0.0, None
+    for entry in entries:
+        if entry.get("type") == "assistant" and previous is not None:
+            gap = (ts(entry["timestamp"]) - ts(previous["timestamp"])).total_seconds()
+            if not blocks(entry, "tool_use") and 0 < gap <= IDLE_SECONDS:
+                model += gap
+        previous = entry
+
+    tool_total = sum(c.duration for c in calls)
+    lead_total = sum(c.lead for c in calls)
+
+    print("TIME")
+    print(f"  wall clock span        {span:8.1f} s")
+    print(f"  idle (gaps > {IDLE_SECONDS:.0f}s)      {idle:8.1f} s   excluded from everything below")
+    print(f"  ACTIVE                 {active:8.1f} s")
+    if active > 0:
+        print(f"    tool execution       {tool_total:8.1f} s  ({tool_total / active * 100:5.1f} %)"
+              f"  {len(calls)} calls")
+        print(f"    model, in tool turns {lead_total:8.1f} s  ({lead_total / active * 100:5.1f} %)")
+        print(f"    model, text only     {model:8.1f} s  ({model / active * 100:5.1f} %)")
+    return active
+
+
+def phases(calls):
+    model = collections.defaultdict(float)
+    tool = collections.defaultdict(float)
+    count = collections.Counter()
+    for call in calls:
+        phase = PHASE_OF.get(short(call.name), "unclassified")
+        model[phase] += call.lead
+        tool[phase] += call.duration
+        count[phase] += 1
+
+    print()
+    print("PHASES")
+    print(f"  {'phase':<14}{'calls':>6}{'model s':>10}{'tool s':>9}{'total s':>10}")
+    for phase in sorted(set(model) | set(tool), key=lambda p: -(model[p] + tool[p])):
+        total = model[phase] + tool[phase]
+        print(f"  {phase:<14}{count[phase]:>6}{model[phase]:>10.1f}{tool[phase]:>9.1f}{total:>10.1f}")
+
+    shell = [c for c in calls if c.name in SHELL]
+    if shell:
+        print(f"  {len(shell)} shell call(s) left unclassified on purpose - what they did, in order:")
+        for call in shell:
+            head = (call.inputs.get("command") or "").replace("\n", " ")[:88]
+            print(f"    {call.duration:5.1f}s  {call.name:<11} {head}")
+
+
+def scorecard(calls):
+    """The four signals a transcript can answer objectively."""
+    print()
+    print("QUALITY")
+
+    # 1. Did the AIXML validate on the first attempt? Later passes mean rework.
+    validates = [c for c in calls if short(c.name) == "validate_aixml"]
+    if not validates:
+        print("  validate first pass    n/a       - no lvai_validate_aixml call")
+    else:
+        codes = [re.search(r'"errorCode"\s*:\s*(-?\d+)', c.result) for c in validates]
+        first = codes[0].group(1) if codes[0] else "?"
+        clean = sum(1 for m in codes if m and m.group(1) == "0")
+        print(f"  validate first pass    {'YES' if first == '0' else 'NO (errorCode ' + first + ')':<9}"
+              f" - {len(validates)} call(s), {clean} clean")
+
+    # 2. The pane tool's own verdict, quoted rather than re-derived.
+    panes = [c for c in calls if short(c.name) == "connector_pane"]
+    measured = [c for c in panes if c.inputs.get("viPath")]
+    if not measured:
+        print(f"  connector pane         NOT MEASURED - {len(panes)} call(s), none with viPath")
+    else:
+        last = measured[-1].result
+        verdict = re.search(r"VERDICT:\s*(.+)", last)
+        counts = re.search(r"(\d+)\s+violations?,\s*(\d+)\s+warnings?", last)
+        if counts:
+            state = f"{counts.group(1)} violations, {counts.group(2)} warnings"
+        elif verdict:
+            state = verdict.group(1).strip()[:70]
+        else:
+            state = "measured, verdict not parsed"
+        print(f"  connector pane         {state}")
+        print(f"                         {len(panes)} pane call(s); 2 is the intended"
+              f" number (before + after)")
+
+    # 3. Regeneration cycles, per target path. A second convert to the SAME path is rework;
+    #    a convert to a different path is usually a separate test VI, which is not.
+    converts = collections.Counter(
+        c.inputs.get("viPath", "?") for c in calls if short(c.name) == "convert_aixml_to_vi")
+    rework = sum(max(0, n - 1) for n in converts.values())
+    print(f"  regeneration cycles    {rework}         - {sum(converts.values())} convert call(s)"
+          f" over {len(converts)} path(s)")
+    for path, n in converts.items():
+        if n > 1:
+            print(f"                         {n}x {path}")
+
+    # 4. Evidence of behavioural checking. Deliberately reported as evidence, not as a
+    #    verdict: whether a run PROVED anything cannot be read off a transcript, and a
+    #    scorecard that pretends otherwise would be worse than none.
+    runs = [c for c in calls
+            if short(c.name) in ("run_vi_and_read_values", "run_vi_as_top_level")]
+    targets = collections.Counter(c.inputs.get("viPath", "?") for c in runs)
+    print(f"  runs executed          {len(runs)}         - over {len(targets)} distinct VI(s)")
+    for path, n in targets.items():
+        print(f"                         {n}x {path}")
+    if len(targets) > 1:
+        print("                         more than one VI was run, which is what an isolated")
+        print("                         behavioural check of a subdiagram looks like")
+
+
+def main(path):
+    entries = load(path)
+    if not entries:
+        print("no timestamped entries")
+        return
+    calls = join_calls(entries)
+    timing(entries, calls)
+    phases(calls)
+    scorecard(calls)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(2)
+    main(sys.argv[1])

--- a/src/LabVIEWMCP/Infra/SymbolicUids.cs
+++ b/src/LabVIEWMCP/Infra/SymbolicUids.cs
@@ -1,0 +1,173 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace LabVIEWMcp.Infra;
+
+/// <summary>
+/// Lets AIXML name its elements instead of numbering them: <c>uid="read"</c> and
+/// <c>outputs="value:read.data"</c> instead of <c>uid="230"</c> and <c>"value:230.data"</c>.
+/// Numbers are assigned here, immediately before the file goes to LabVIEW, which never sees a
+/// symbol.
+///
+/// WHY. Profiling a whole VI generation put a single turn of 47 s on "planning out the unique
+/// uids" - pure notation overhead with no bearing on what the diagram does. The format needs the
+/// numbers; the author does not need to keep a numbering scheme in their head while doing so.
+///
+/// THREE SAFETY PROPERTIES, because this sits between an author and code generation and a mistake
+/// here is a silently miswired VI rather than an error:
+///
+///   1. A file with no symbolic uid is NOT rewritten at all - <see cref="Prepare"/> hands back the
+///      original path. Existing AIXML cannot be perturbed by a bug in this class.
+///   2. The mapping is injective by construction (one dictionary entry per distinct symbol) and
+///      cannot collide with a number already in the file, because numbering starts above the
+///      highest numeric uid present. Two symbols sharing a number would produce a VI that
+///      validates, runs, and is wired wrongly - the one failure mode worth this much care.
+///   3. Substitution happens only where a net reference can legally appear: as a whole
+///      <c>uid</c>/<c>uid_parent</c> value, or immediately before the dot of a
+///      <c>&lt;uid&gt;.&lt;terminal&gt;</c> reference at the start of an attribute or after a
+///      comma or colon. Prose-carrying attributes are excluded outright.
+/// </summary>
+internal static class SymbolicUids
+{
+    /// <summary>What a symbol may look like. Never all digits - that is a number, not a symbol.</summary>
+    private static readonly Regex Symbol = new(@"^[A-Za-z_][A-Za-z0-9_\-]*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Attributes whose value is free text a user wrote. A net reference never appears in one, and
+    /// a description mentioning "read.data" must not be rewritten into "read.230".
+    /// </summary>
+    private static readonly HashSet<string> Prose =
+        new(StringComparer.Ordinal) { "description", "value", "text", "label", "comment", "_name" };
+
+    internal sealed record Result(
+        string PathForLabview,
+        IReadOnlyDictionary<string, int> Map,
+        bool Rewritten);
+
+    /// <summary>
+    /// Returns the path to hand to LabVIEW. When the file uses no symbolic uid this is
+    /// <paramref name="aixmlPath"/> itself, untouched; otherwise a rewritten copy beside it in
+    /// TEMP, kept rather than deleted so the numbers LabVIEW actually saw can be inspected.
+    /// </summary>
+    /// <exception cref="FormatException">A uid is neither a number nor a legal symbol.</exception>
+    internal static Result Prepare(string aixmlPath)
+    {
+        XDocument document;
+        try
+        {
+            document = XDocument.Load(aixmlPath, LoadOptions.PreserveWhitespace);
+        }
+        catch (Exception e) when (e is System.Xml.XmlException or IOException
+                                    or UnauthorizedAccessException or NotSupportedException
+                                    or ArgumentException)
+        {
+            // ANYTHING this cannot read goes to LabVIEW unchanged: a missing file, an unreadable
+            // one, malformed XML. Its diagnosis is the AIXML-specific one an author is used to,
+            // and a file that does not parse here cannot contain a symbol needing resolution.
+            //
+            // Measured, not anticipated: without this, 13 existing tests broke at once. They pass
+            // paths like C:\p\src.xml that never existed, and the tool used to forward them so
+            // LabVIEW could say so. Loading the file first turned that into a
+            // DirectoryNotFoundException raised before LabVIEW was asked - a worse message, for
+            // callers who are not using this feature at all. Being inert on anything unreadable is
+            // the whole safety story of this class; it is the same rule as the passthrough above.
+            return new Result(aixmlPath, new Dictionary<string, int>(), false);
+        }
+
+        var symbols = new List<string>();       // document order, so numbering is deterministic
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var highest = 0;
+
+        foreach (var element in document.Descendants())
+        {
+            foreach (var name in new[] { "uid", "uid_parent" })
+            {
+                var value = element.Attribute(name)?.Value;
+                if (string.IsNullOrEmpty(value)) continue;
+
+                if (int.TryParse(value, out var number))
+                {
+                    highest = Math.Max(highest, number);
+                    continue;
+                }
+                // "root" is the format's own name for the top-level diagram, not a symbol.
+                if (value == "root") continue;
+
+                if (!Symbol.IsMatch(value))
+                    throw new FormatException(
+                        $"'{value}' is not usable as a {name}: a symbolic uid must start with a " +
+                        "letter or underscore and contain only letters, digits, underscore or " +
+                        "hyphen. Dots and colons are reserved - they separate a uid from a " +
+                        "terminal name.");
+
+                if (seen.Add(value)) symbols.Add(value);
+            }
+        }
+
+        if (symbols.Count == 0)
+            return new Result(aixmlPath, new Dictionary<string, int>(), false);
+
+        // Above every number already present, so a symbol can never take a number the author used.
+        var next = highest + 1;
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var symbol in symbols) map[symbol] = next++;
+
+        foreach (var element in document.Descendants())
+            foreach (var attribute in element.Attributes())
+                attribute.Value = Substitute(attribute.Name.LocalName, attribute.Value, map);
+
+        var target = RewrittenPath(aixmlPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+        document.Save(target, SaveOptions.DisableFormatting);
+        return new Result(target, map, true);
+    }
+
+    /// <summary>
+    /// One attribute's value with symbols replaced. Whole-value for <c>uid</c>/<c>uid_parent</c>,
+    /// and otherwise only in front of the dot of a net reference.
+    /// </summary>
+    private static string Substitute(
+        string attribute, string value, IReadOnlyDictionary<string, int> map)
+    {
+        if (attribute is "uid" or "uid_parent")
+            return map.TryGetValue(value, out var number) ? number.ToString() : value;
+
+        if (Prose.Contains(attribute) || value.Length == 0) return value;
+
+        // A net reference is "<uid>.<terminal>", appearing either alone (count="n.value"), or in a
+        // comma-separated list where each entry is "<terminal>:<uid>.<terminal>". So the uid is
+        // preceded by the start of the value, a comma or a colon, and followed by a dot.
+        return Regex.Replace(value, @"(?<=^|[,:])([A-Za-z_][A-Za-z0-9_\-]*)(?=\.)",
+            match => map.TryGetValue(match.Groups[1].Value, out var number)
+                ? number.ToString()
+                : match.Value);
+    }
+
+    /// <summary>
+    /// Put the symbols back into a message LabVIEW wrote about the rewritten file.
+    ///
+    /// Deliberately conservative: only <c>uid="123"</c> and <c>uid 123</c> are translated, because
+    /// those are unambiguous. A bare number is NOT touched - LabVIEW's messages are full of error
+    /// codes, and turning "-200220" or "Error 1357" into a symbol name would be a worse failure
+    /// than leaving a number untranslated. The full map travels with the response, so anything
+    /// this misses is one lookup away rather than a mystery.
+    /// </summary>
+    internal static string Annotate(string message, IReadOnlyDictionary<string, int> map)
+    {
+        if (string.IsNullOrEmpty(message) || map.Count == 0) return message;
+
+        var back = map.ToDictionary(pair => pair.Value.ToString(), pair => pair.Key);
+        return Regex.Replace(message, @"\buid\s*=?\s*""?(\d+)""?",
+            match => back.TryGetValue(match.Groups[1].Value, out var symbol)
+                ? match.Value.Replace(match.Groups[1].Value, symbol)
+                : match.Value);
+    }
+
+    /// <summary>
+    /// Beside the source file's name but under TEMP, and kept. A caller that has to reconcile a
+    /// LabVIEW message with what it wrote needs to be able to open the numbered file.
+    /// </summary>
+    private static string RewrittenPath(string aixmlPath) =>
+        Path.Combine(Path.GetTempPath(), "LabVIEWMCP", "symbolic",
+            Path.GetFileNameWithoutExtension(aixmlPath) + ".numbered.xml");
+}

--- a/src/LabVIEWMCP/Tools/AixmlTools.cs
+++ b/src/LabVIEWMCP/Tools/AixmlTools.cs
@@ -305,13 +305,19 @@ internal sealed class AixmlTools(LvaiConnection connection)
             // what a step costs is to bracket the call from outside, which in an agent loop
             // measures model latency - about 7 s per turn - rather than LabVIEW. Measured that
             // way, three calls read 30.4 s while the work was well under a second.
+            var symbolic = SymbolicUids.Prepare(aiXmlFilePath);
+
             var stopwatch = Stopwatch.StartNew();
             var response = await connection.InvokeAsync((c, t) =>
-                c.ValidateAIXMLAsync(new ValidateAIXMLRequest { AiXMLFilePath = aiXmlFilePath },
+                c.ValidateAIXMLAsync(
+                    new ValidateAIXMLRequest { AiXMLFilePath = symbolic.PathForLabview },
                     deadline: Rpc.Deadline(timeoutSeconds), cancellationToken: t).ResponseAsync, ct);
             stopwatch.Stop();
+
+            response.ErrorMessage = SymbolicUids.Annotate(response.ErrorMessage, symbolic.Map);
             return Json.Message(response,
-                ("elapsedMs", JsonValue.Create(stopwatch.ElapsedMilliseconds)));
+                [.. SymbolicFacts(symbolic),
+                 ("elapsedMs", JsonValue.Create(stopwatch.ElapsedMilliseconds))]);
         });
 
     [McpServerTool(Name = "lvai_convert_aixml_to_vi", Destructive = true, OpenWorld = true,
@@ -342,22 +348,26 @@ internal sealed class AixmlTools(LvaiConnection connection)
             // This is the number people actually ask for - "how long does generating a VI take" -
             // and it is not obtainable from outside the server: bracketing the call in an agent
             // loop measures the turn, not the generation.
+            var symbolic = SymbolicUids.Prepare(aiXmlFilePath);
+
             var stopwatch = Stopwatch.StartNew();
             var response = await connection.InvokeAsync((c, t) =>
                 c.ConvertAIXMLToVIAsync(new ConvertAIXMLToVIRequest
                 {
-                    AiXMLFilePath = aiXmlFilePath,
+                    AiXMLFilePath = symbolic.PathForLabview,
                     ViPath = viPath,
                     OpenVI = openVI,
                 }, deadline: Rpc.Deadline(timeoutSeconds), cancellationToken: t).ResponseAsync, ct);
             stopwatch.Stop();
 
+            response.ErrorMessage = SymbolicUids.Annotate(response.ErrorMessage, symbolic.Map);
             return Json.Message(response,
-                ("viPath", JsonValue.Create(Path.GetFullPath(viPath))),
-                ("viExisted", JsonValue.Create(existedBefore)),
-                ("viExistsNow", JsonValue.Create(File.Exists(viPath))),
-                ("viBytes", JsonValue.Create(File.Exists(viPath) ? new FileInfo(viPath).Length : 0)),
-                ("elapsedMs", JsonValue.Create(stopwatch.ElapsedMilliseconds)));
+                [.. SymbolicFacts(symbolic),
+                 ("viPath", JsonValue.Create(Path.GetFullPath(viPath))),
+                 ("viExisted", JsonValue.Create(existedBefore)),
+                 ("viExistsNow", JsonValue.Create(File.Exists(viPath))),
+                 ("viBytes", JsonValue.Create(File.Exists(viPath) ? new FileInfo(viPath).Length : 0)),
+                 ("elapsedMs", JsonValue.Create(stopwatch.ElapsedMilliseconds))]);
         });
 
     [McpServerTool(Name = "lvai_apply_aixml_to_vi", Destructive = true, OpenWorld = true,
@@ -375,21 +385,45 @@ internal sealed class AixmlTools(LvaiConnection connection)
         await Rpc.GuardAsync(async () =>
         {
             var before = File.Exists(viPath) ? new FileInfo(viPath).Length : 0;
+            var symbolic = SymbolicUids.Prepare(aiXmlFilePath);
             var response = await connection.InvokeAsync((c, t) =>
                 c.ApplyAIXMLToVIAsync(new ApplyAIXMLToVIRequest
                 {
                     ViPath = viPath,
-                    AiXMLFilePath = aiXmlFilePath,
+                    AiXMLFilePath = symbolic.PathForLabview,
                 }, deadline: Rpc.Deadline(timeoutSeconds), cancellationToken: t).ResponseAsync, ct);
 
+            response.ErrorMessage = SymbolicUids.Annotate(response.ErrorMessage, symbolic.Map);
             return Json.Message(response,
-                ("viBytesBefore", JsonValue.Create(before)),
-                ("viBytesAfter", JsonValue.Create(
-                    File.Exists(viPath) ? new FileInfo(viPath).Length : 0)),
-                ("note", JsonValue.Create(
-                    "A byte size that did not change may simply mean LabVIEW has the VI open " +
-                    "in memory and has not saved it yet.")));
+                [.. SymbolicFacts(symbolic),
+                 ("viBytesBefore", JsonValue.Create(before)),
+                 ("viBytesAfter", JsonValue.Create(
+                     File.Exists(viPath) ? new FileInfo(viPath).Length : 0)),
+                 ("note", JsonValue.Create(
+                     "A byte size that did not change may simply mean LabVIEW has the VI open " +
+                     "in memory and has not saved it yet."))]);
         });
+
+    /// <summary>
+    /// What to add to a response when the source used symbolic uids - nothing at all when it did
+    /// not, so an ordinary numbered file's answer keeps exactly the shape it always had.
+    /// </summary>
+    private static (string, JsonNode?)[] SymbolicFacts(SymbolicUids.Result symbolic)
+    {
+        if (!symbolic.Rewritten) return [];
+
+        var map = new JsonObject();
+        foreach (var pair in symbolic.Map) map[pair.Key] = JsonValue.Create(pair.Value);
+
+        return [
+            ("symbolicUids", map),
+            ("aiXmlSentToLabview", JsonValue.Create(symbolic.PathForLabview)),
+            ("symbolicNote", JsonValue.Create(
+                "This source used symbolic uids; they were numbered before LabVIEW saw it. A " +
+                "message naming a number refers to the file at aiXmlSentToLabview, and " +
+                "symbolicUids gives the symbol each number came from.")),
+        ];
+    }
 
     private static async Task<(string, JsonNode?)[]> FileFactsAsync(
         string path, bool includeContent, int maxChars, CancellationToken ct)

--- a/tests/LabVIEWMCP.Tests/Infra/SymbolicUidsTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/SymbolicUidsTests.cs
@@ -1,0 +1,276 @@
+using System.Xml.Linq;
+using LabVIEWMcp.Infra;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Infra;
+
+/// <summary>
+/// Symbolic uids sit between an author and code generation, so the tests that matter are the
+/// safety ones rather than the feature ones. A wrong number here does not fail - it produces a VI
+/// that validates, runs, and is wired to the wrong terminal. Three properties are therefore pinned
+/// explicitly: untouched passthrough, injectivity, and no collision with numbers already used.
+/// </summary>
+public sealed class SymbolicUidsTests : IDisposable
+{
+    private readonly string _dir = Directory.CreateTempSubdirectory("lvai-symbolic-tests").FullName;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { }
+    }
+
+    private string Write(string name, string xml)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, xml);
+        return path;
+    }
+
+    private static XDocument Load(string path) => XDocument.Load(path);
+
+    private static XElement ByName(XDocument document, string name) =>
+        document.Descendants().Single(e => (string?)e.Attribute("_name") == name);
+
+    // ---- passthrough ----
+
+    [Fact]
+    public void Leaves_a_file_without_symbols_completely_alone()
+    {
+        var path = Write("plain.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:10.value" type="int32" uid="10" uid_parent="root" value="5"/>
+              <Indicator _name="out" inputs="value:10.value" type="int32" uid="20" uid_parent="root"/>
+            </VI>
+            """);
+        var before = File.ReadAllBytes(path);
+
+        var result = SymbolicUids.Prepare(path);
+
+        Assert.False(result.Rewritten);
+        Assert.Equal(path, result.PathForLabview);     // the very same file, not a copy
+        Assert.Empty(result.Map);
+        Assert.Equal(before, File.ReadAllBytes(path)); // and untouched on disk
+    }
+
+    [Fact]
+    public void Hands_malformed_xml_to_labview_rather_than_reporting_its_own_parse_error()
+    {
+        // LabVIEW's diagnosis of broken AIXML is the one authors know. Adding this feature must
+        // not change the error message of files that never used it.
+        var path = Write("broken.xml", "<VI _name=\"X.vi\"><Constant uid=\"10\"></VI>");
+
+        var result = SymbolicUids.Prepare(path);
+
+        Assert.False(result.Rewritten);
+        Assert.Equal(path, result.PathForLabview);
+    }
+
+    // ---- numbering ----
+
+    [Fact]
+    public void Hands_a_path_that_does_not_exist_to_labview_rather_than_throwing()
+    {
+        // Regression, found by 13 existing tests breaking at once: they pass paths that were
+        // never created, and the tool used to forward them so LabVIEW could report the problem.
+        // Reading the file first turned that into a DirectoryNotFoundException raised before
+        // LabVIEW was asked - a worse message for callers not using symbolic uids at all.
+        var missing = Path.Combine(_dir, "nowhere", "gone.xml");
+
+        var result = SymbolicUids.Prepare(missing);
+
+        Assert.False(result.Rewritten);
+        Assert.Equal(missing, result.PathForLabview);
+        Assert.Empty(result.Map);
+    }
+
+    [Fact]
+    public void Numbers_symbols_above_every_number_already_in_the_file()
+    {
+        var path = Write("mixed.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:500.value" type="int32" uid="500" uid_parent="root" value="5"/>
+              <Node _name="Increment" inputs="x:500.value" outputs="x+1:inc.x+1" uid="inc" uid_parent="root"/>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+
+        Assert.True(result.Rewritten);
+        Assert.True(result.Map["inc"] > 500,
+            $"'inc' got {result.Map["inc"]}, which collides with the 500 already in the file");
+    }
+
+    [Fact]
+    public void Gives_every_distinct_symbol_a_distinct_number()
+    {
+        var path = Write("many.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:a.value" type="int32" uid="a" uid_parent="root" value="1"/>
+              <Constant outputs="value:b.value" type="int32" uid="b" uid_parent="root" value="2"/>
+              <Node _name="Add" inputs="x:a.value,y:b.value" outputs="x+y:sum.x+y" uid="sum" uid_parent="root"/>
+              <Indicator _name="out" inputs="value:sum.x+y" type="int32" uid="c" uid_parent="root"/>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+
+        Assert.Equal(4, result.Map.Count);
+        Assert.Equal(result.Map.Count, result.Map.Values.Distinct().Count());
+    }
+
+    // ---- substitution ----
+
+    [Fact]
+    public void Rewrites_net_references_wherever_they_legally_appear()
+    {
+        var path = Write("nets.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:n.value" type="int32" uid="n" uid_parent="root" value="5"/>
+              <Structure _name="For Loop" count="" maxin="n.value" maxout="" uid="loop" uid_parent="root">
+                <Tunnel _id="In1" inputs="value:n.value" mode="index" outputs="value:t.value" uid="t" uid_parent="loop"/>
+              </Structure>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+        var document = Load(result.PathForLabview);
+        var n = result.Map["n"];
+        var loop = result.Map["loop"];
+
+        var structure = document.Descendants("Structure").Single();
+        Assert.Equal($"{n}.value", (string?)structure.Attribute("maxin"));
+        Assert.Equal(loop.ToString(), (string?)structure.Attribute("uid"));
+
+        var tunnel = document.Descendants("Tunnel").Single();
+        Assert.Equal($"value:{n}.value", (string?)tunnel.Attribute("inputs"));
+        Assert.Equal(loop.ToString(), (string?)tunnel.Attribute("uid_parent"));
+    }
+
+    [Fact]
+    public void Rewrites_every_entry_of_a_comma_separated_list()
+    {
+        var path = Write("list.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:a.value" type="int32" uid="a" uid_parent="root" value="1"/>
+              <Constant outputs="value:b.value" type="int32" uid="b" uid_parent="root" value="2"/>
+              <Node _name="Add" inputs="x:a.value,y:b.value" outputs="x+y:s.x+y" uid="s" uid_parent="root"/>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+        var add = ByName(Load(result.PathForLabview), "Add");
+
+        Assert.Equal($"x:{result.Map["a"]}.value,y:{result.Map["b"]}.value",
+                     (string?)add.Attribute("inputs"));
+    }
+
+    [Fact]
+    public void Leaves_root_alone_because_it_is_the_format_s_own_name()
+    {
+        var path = Write("root.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:a.value" type="int32" uid="a" uid_parent="root" value="1"/>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+
+        Assert.DoesNotContain("root", result.Map.Keys);
+        Assert.Equal("root",
+            (string?)Load(result.PathForLabview).Descendants("Constant").Single()
+                .Attribute("uid_parent"));
+    }
+
+    [Fact]
+    public void Never_touches_an_attribute_that_carries_prose()
+    {
+        // A description mentioning "read.data" is documentation, not a wire.
+        var path = Write("prose.xml", """
+            <VI _name="X.vi" description="Wires read.data into the output.">
+              <Constant _name="read" description="feeds read.data" outputs="value:read.value"
+                        type="string" uid="read" uid_parent="root" value="read.data"/>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+        var document = Load(result.PathForLabview);
+        var constant = document.Descendants("Constant").Single();
+
+        Assert.Equal("Wires read.data into the output.",
+                     (string?)document.Root!.Attribute("description"));
+        Assert.Equal("feeds read.data", (string?)constant.Attribute("description"));
+        Assert.Equal("read.data", (string?)constant.Attribute("value"));
+        Assert.Equal("read", (string?)constant.Attribute("_name"));
+        // ...while the net reference beside them IS rewritten
+        Assert.Equal($"value:{result.Map["read"]}.value", (string?)constant.Attribute("outputs"));
+    }
+
+    [Fact]
+    public void Leaves_no_symbol_behind_in_the_file_labview_receives()
+    {
+        var path = Write("complete.xml", """
+            <VI _name="X.vi">
+              <Control _name="in" conIdx="0" outputs="value:src.value" type="string" uid="src" uid_parent="root" value=""/>
+              <Node _name="String Length" inputs="string:src.value" outputs="length:len.length" uid="len" uid_parent="root"/>
+              <Indicator _name="out" conIdx="4" inputs="value:len.length" type="int32" uid="sink" uid_parent="root"/>
+            </VI>
+            """);
+
+        var result = SymbolicUids.Prepare(path);
+        var text = File.ReadAllText(result.PathForLabview);
+
+        foreach (var symbol in result.Map.Keys)
+            Assert.DoesNotContain($"\"{symbol}\"", text);
+        Assert.DoesNotContain("src.", text);
+        Assert.DoesNotContain("len.", text);
+    }
+
+    [Fact]
+    public void Refuses_a_uid_that_is_neither_a_number_nor_a_legal_symbol()
+    {
+        var path = Write("bad.xml", """
+            <VI _name="X.vi">
+              <Constant outputs="value:a.b.value" type="int32" uid="a.b" uid_parent="root" value="1"/>
+            </VI>
+            """);
+
+        var error = Assert.Throws<FormatException>(() => SymbolicUids.Prepare(path));
+
+        Assert.Contains("a.b", error.Message);
+        Assert.Contains("Dots and colons are reserved", error.Message);
+    }
+
+    // ---- messages back ----
+
+    [Fact]
+    public void Puts_the_symbol_back_into_a_message_naming_a_uid()
+    {
+        var map = new Dictionary<string, int> { ["read"] = 501, ["loop"] = 502 };
+
+        Assert.Equal("Object terminal not found for uid=\"read\"",
+                     SymbolicUids.Annotate("Object terminal not found for uid=\"501\"", map));
+        Assert.Equal("uid loop has no terminal",
+                     SymbolicUids.Annotate("uid 502 has no terminal", map));
+    }
+
+    [Fact]
+    public void Leaves_bare_numbers_alone_so_an_error_code_survives()
+    {
+        // Turning "-200220" or "Error 1357" into a symbol name would be a worse failure than
+        // leaving a number untranslated, so only an explicit uid is rewritten.
+        var map = new Dictionary<string, int> { ["read"] = 1357 };
+
+        Assert.Equal("Error 1357 occurred: a file from that path is already in memory",
+            SymbolicUids.Annotate(
+                "Error 1357 occurred: a file from that path is already in memory", map));
+    }
+
+    [Fact]
+    public void Returns_a_message_unchanged_when_nothing_was_symbolic()
+    {
+        var empty = new Dictionary<string, int>();
+
+        Assert.Equal("For Loop: N is not wired",
+                     SymbolicUids.Annotate("For Loop: N is not wired", empty));
+    }
+}


### PR DESCRIPTION
Both target the same measured cost. Profiling four generations showed LabVIEW and the MCP server at 14-17 % of wall clock; the rest is model time, and its largest single component was notation - one 47 s turn spent planning uid numbers, plus the typing of ~11 kB of XML.

Symbolic uids: `uid="read"`, `outputs="value:read.data"`. The server numbers them before LabVIEW sees the file. Three safety properties, since a wrong number yields a VI that validates, runs and is wired wrongly rather than an error - the mapping is injective, numbering starts above every number already in the file, and anything unreadable (missing file, malformed XML) is passed through untouched. That last one is not a nicety: without it 13 existing tests broke at once, because they pass paths that never existed and relied on LabVIEW to report them.

Skeletons: scripts/aixml-skeletons/, validated AIXML to copy shapes from. They carry no conIdx and their headers date every station-specific claim, because a frozen measurement is how "a generated VI always gets pattern 4815" once shipped a wrong connector pane.

Measured over six comparable runs of the same VI at equal reasoning effort - the earlier comparison was confounded by an effort change and is void:

    without   450.2  578.7                    mean 514.5, spread 128.5
    with      418.7  408.5  411.4  360.2      mean 399.7, spread  58.5

The groups do not overlap, but the control group is only two runs, so this is an indication and not a result. Quality did not regress: all four runs validated on the first attempt, needed no regeneration, and measured the accumulator behaviourally at 3 channels x 500 samples. The one run that ever fell below that was a control run.

Also here, because the runs surfaced them:

- generation_scorecard.py, reporting time and four quality signals from a transcript. Quality has to be visible or optimisation only ever sees the clock.
- TDMS Open with create-or-replace accepts a bare relative name, returns code 0, and writes into C:\Program Files (x86)\...\LabVIEW 2026\. The 1430/7 codes in the reference were measured on a read and do not transfer to a create. An empty path returns 118 in 25 ms with no dialog, so the guard four generated VIs added was unnecessary.
- The claim that an XML comment fails ValidateAIXML no longer reproduces.