### PR TITLE
Answer a bad tool argument with data instead of a masked sentence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,22 @@ produced its 419-row table in 16 seconds and still stayed a script plus a `docs/
 it only needs re-running after an addon update. When it is genuinely borderline, build the script,
 say plainly that it could become a tool, and let the caller decide.
 
+## When a tool call fails
+
+**`An error occurred invoking 'lvai_…'` is OUR message, not the client's.** It is the MCP SDK masking
+an exception thrown while binding the arguments, and the detail — exception, stack, the parameter at
+fault — goes to the server's **stderr**, where no client looks. Issue #19 concluded the opposite, that
+a client rejected the call before it ever reached the server; the first reading of that issue in this
+repository agreed with it. Both were wrong, measured 2026-08-14 by driving the built exe over raw
+stdio with no client in between: same call, same sentence.
+
+Since then the server answers argument problems with data. A near-miss spelling is folded onto the
+declared one (`vi_path` → `viPath`, `max_content_chars` → `maxContentChars`), and a genuinely missing
+argument comes back as `{"ok": false, "errorKind": "badArguments", …}` naming what is missing, what
+arrived, and every accepted name with its type. So **seeing the masked sentence again means the
+wrapper is not in place** — check that `WithArgumentDiagnostics()` still runs last in `Program.cs`,
+and read stderr. Detail and the re-measuring recipe in `docs/tool-argument-errors.md`.
+
 ## Writing things down
 
 **Empirically derived `lvai` behaviour belongs in `docs/`, not only in the conversation.** This
@@ -290,6 +306,7 @@ literally it argued away 600 usable palette VIs.
 | How do I build a new VI, end to end? | `.claude/agents/labview-vi-generator.md` | — |
 | How do I change an existing VI? | `.claude/agents/labview-vi-editor.md` | — |
 | How do I document LabVIEW code? | `.claude/agents/labview-doc-generator.md` | — |
+| Why did a tool call fail with no detail? | `docs/tool-argument-errors.md` | — |
 
 The seven documents served by an `lvai_*_reference` tool are **embedded in the assembly** and
 byte-verified on every build, so a binary-only install answers the same questions. See "Installing

--- a/docs/tool-argument-errors.md
+++ b/docs/tool-argument-errors.md
@@ -1,0 +1,95 @@
+# Why a tool call failed with no detail
+
+Reported as [issue #19](https://github.com/Zuehlke/labview-mcp/issues/19), measured and fixed on
+2026-08-14. Read this before diagnosing an argument problem, because the symptom points at the
+wrong culprit and the report itself got it wrong.
+
+## The symptom
+
+A call with the wrong spelling of a parameter answered exactly this, and nothing else:
+
+```json
+{ "isError": true, "content": [ { "type": "text",
+  "text": "An error occurred invoking 'lvai_describe_vi'." } ] }
+```
+
+No parameter named, no hint. What it cost the reporter: **nine identical failures**, and a session
+spent on a LabVIEW-version-mismatch hypothesis before anyone suspected a parameter name.
+
+## Where the message comes from — not where it looks like
+
+The issue concluded that the client's schema validation rejected the call "before requests reach the
+server". **It does not.** Measured by driving the built server over raw stdio with no client in
+between: the same call, the same sentence. The chain is
+
+1. the request arrives, and the SDK binds the JSON arguments to the C# parameters;
+2. binding throws — inside `AIFunctionMcpServerTool.InvokeAsync`, which the stderr stack trace shows;
+3. `McpServerImpl` masks the exception to `An error occurred invoking '<tool>'.`;
+4. the exception and its stack go to **stderr**, which for a stdio server is the log — no client
+   looks there.
+
+So the useful diagnosis existed all along and was written to a channel nobody reads. That is also
+the good news: because the call does reach us, a server-side answer is possible at all.
+
+The same run measured the other half: **an undeclared argument key is dropped in silence.** So
+`{"vi_path": "..."}` was indistinguishable from `{}` — hence "missing required argument", hence the
+masked sentence.
+
+## What the server does now
+
+`Infra/DiagnosingTool.cs` wraps every registered tool (`DelegatingMcpServerTool`, the SDK's own
+extension point) and `Infra/ToolArguments.cs` holds the logic. Two steps, in order:
+
+1. **Fold.** A supplied key that differs from a declared one only in `_`, `-` or case is renamed to
+   the declared spelling. `vi_path` → `viPath`, `max_content_chars` → `maxContentChars`. A key that
+   is already declared is never overwritten by a variant, and two declared names sharing a fold are
+   left alone rather than guessed between.
+2. **Report.** A required key still absent answers with data:
+
+```json
+{ "ok": false, "errorKind": "badArguments",
+  "error": "lvai_convert_vi_to_aixml was called without the required argument 'aiXmlFilePath'.",
+  "detail": {
+    "tool": "lvai_convert_vi_to_aixml",
+    "missing": [ "aiXmlFilePath" ],
+    "received": [ "viPath" ],
+    "accepted": { "viPath": "string, required", "aiXmlFilePath": "string, required",
+                  "returnContent": "boolean, default true", "maxContentChars": "integer, default 60000",
+                  "timeoutSeconds": "integer, default 180", "refresh": "boolean, default false" },
+    "hint": "Argument names are camelCase and are listed under 'accepted'. ..." } }
+```
+
+`accepted` is read out of the tool's own served schema, so it cannot drift from what `tools/list`
+advertises. The schema keeps its `required` array: nothing was made optional to achieve this, and no
+tool signature moved.
+
+A call that fails **inside** the binding for any other reason - a wrong JSON type, mostly - gets the
+same envelope with the exception message that would otherwise have been masked.
+
+## Limits worth knowing
+
+- **A wrong type is reported but not located.** The SDK's own message is
+  `The JSON value could not be converted to System.Int32. Path: $ | LineNumber: 0 |
+  BytePositionInLine: 6.` — it does not name the argument. `received` plus `accepted` is how to find
+  it; the types in `accepted` are the authority.
+- **Folding covers near-misses of declared names, not synonyms.** `vi_path` works because `viPath`
+  exists; `path` or `file` is still an unknown key, and an unknown key is still ignored - that is the
+  MCP contract, not something this layer overrides.
+- **The wrapper must be registered last.** `WithArgumentDiagnostics()` rewrites the tool
+  registrations that are already in the collection, so a tool registered after it is not wrapped.
+  `DiagnosingToolTests` asserts that every served tool comes back wrapped, so an SDK upgrade that
+  registers tools differently fails there rather than silently restoring the masked sentence.
+
+## Re-measuring it
+
+No client and no test host needed - a built exe, and JSON-RPC lines on stdin. Send `initialize`,
+then `notifications/initialized`, then:
+
+```json
+{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"lvai_describe_vi","arguments":{"vi_path":"C:\\x\\My.vi"}}}
+```
+
+Before the fix that answered the masked sentence; after it, the call runs with `viPath` folded in.
+`{"name":"lvai_convert_vi_to_aixml","arguments":{"viPath":"C:\\x\\My.vi"}}` is the missing-argument
+case, and `{"timeoutSeconds":"soon"}` the wrong-type one. Read the server's **stderr** alongside: it
+is where the pre-fix detail always was.

--- a/src/LabVIEWMCP/Infra/DiagnosingTool.cs
+++ b/src/LabVIEWMCP/Infra/DiagnosingTool.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace LabVIEWMcp.Infra;
+
+/// <summary>
+/// Every served tool, wrapped so that a bad ARGUMENT is answerable. <see cref="ToolArguments"/> has
+/// the measurement and the reasoning; this is the shell that applies it.
+///
+/// A wrapper rather than a change to 26 required parameters across 20 tools: the schema keeps its
+/// `required` array - which is real information for the caller - and no tool signature moves.
+/// `DelegatingMcpServerTool` is the SDK's own extension point for this ("recommended as a base type
+/// when building tools that can be chained around an underlying McpServerTool"), and the binding
+/// failure this class catches was measured to be thrown INSIDE the inner tool's InvokeAsync, which
+/// is what makes it reachable from here at all.
+/// </summary>
+internal sealed class DiagnosingTool(McpServerTool inner) : DelegatingMcpServerTool(inner)
+{
+    public override async ValueTask<CallToolResult> InvokeAsync(
+        RequestContext<CallToolRequestParams> request,
+        CancellationToken cancellationToken = default)
+    {
+        var name = ProtocolTool.Name;
+        var schema = ProtocolTool.InputSchema;
+        var (properties, required) = ToolArguments.Shape(schema);
+
+        var supplied = request.Params?.Arguments;
+        // Captured before any renaming, because what the CALLER wrote is the useful half of the
+        // report: "you sent vi_path" is what lets the next call be right.
+        var received = supplied is null ? [] : supplied.Keys.ToList();
+
+        if (request.Params is { } parameters && supplied is { Count: > 0 })
+        {
+            var renames = ToolArguments.Renames(properties, received);
+            if (renames.Count > 0)
+            {
+                // A fresh dictionary rather than an in-place edit: `Arguments` is an IDictionary,
+                // but nothing promises the instance the transport built is writable.
+                var folded = new Dictionary<string, JsonElement>(supplied, StringComparer.Ordinal);
+                foreach (var (from, to) in renames)
+                {
+                    folded[to] = folded[from];
+                    folded.Remove(from);
+                }
+
+                parameters.Arguments = folded;
+                supplied = folded;
+            }
+        }
+
+        var missing = ToolArguments.Missing(required, supplied?.Keys.ToList());
+        if (missing.Count > 0)
+            return Failure(ToolArguments.MissingArguments(name, schema, missing, received));
+
+        try
+        {
+            return await base.InvokeAsync(request, cancellationToken);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            return Failure(ToolArguments.InvocationProblem(name, schema, received, e));
+        }
+    }
+
+    /// <summary>
+    /// Reported as a tool error carrying the JSON, not as a thrown exception: measured, the content
+    /// of an `isError` result reaches the client verbatim, whereas an exception is what gets masked.
+    /// </summary>
+    private static CallToolResult Failure(string json) => new()
+    {
+        IsError = true,
+        Content = [new TextContentBlock { Text = json }],
+    };
+}
+
+internal static class DiagnosingToolExtensions
+{
+    /// <summary>
+    /// Wrap every tool registered so far. MUST be called AFTER the registration that adds them
+    /// (<c>WithToolsFromAssembly</c>), because it rewrites the descriptors that are already there;
+    /// a tool registered afterwards would not be wrapped. The test suite asserts that every served
+    /// tool comes back wrapped, so a future SDK that registers tools differently fails there rather
+    /// than degrading in silence back to "An error occurred invoking '...'".
+    /// </summary>
+    public static IMcpServerBuilder WithArgumentDiagnostics(this IMcpServerBuilder builder)
+    {
+        var services = builder.Services;
+        for (var i = 0; i < services.Count; i++)
+        {
+            var existing = services[i];
+            if (existing.ServiceType != typeof(McpServerTool) || existing.IsKeyedService) continue;
+
+            services[i] = ServiceDescriptor.Describe(
+                typeof(McpServerTool),
+                provider => new DiagnosingTool(Inner(existing, provider)),
+                existing.Lifetime);
+        }
+
+        return builder;
+    }
+
+    /// <summary>The tool the original registration would have produced, whichever shape it used.</summary>
+    private static McpServerTool Inner(ServiceDescriptor descriptor, IServiceProvider provider) =>
+        (McpServerTool)(descriptor.ImplementationInstance
+            ?? descriptor.ImplementationFactory?.Invoke(provider)
+            ?? ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType!));
+}

--- a/src/LabVIEWMCP/Infra/Json.cs
+++ b/src/LabVIEWMCP/Infra/Json.cs
@@ -36,11 +36,35 @@ internal static class Json
     }
 
     /// <summary>A stream result: the collected messages plus why collection stopped.</summary>
-    public static string Stream(IEnumerable<IMessage> messages, string stopReason, int limit)
+    public static string Stream(IEnumerable<IMessage> messages, string stopReason, int limit) =>
+        Stream(messages, stopReason, limit, 0);
+
+    /// <summary>
+    /// The same, with a cap on named string fields - the convention of `xml` / `xmlTruncated` in the
+    /// AIXML tools, applied to a stream. A cap of 0 leaves every message whole, which is why the
+    /// three-argument overload above can forward to this one unchanged.
+    /// </summary>
+    public static string Stream(IEnumerable<IMessage> messages, string stopReason, int limit,
+                                int maxFieldChars, params string[] cappedFields)
     {
         var arr = new JsonArray();
         var count = 0;
-        foreach (var m in messages) { arr.Add(Node(m)); count++; }
+        foreach (var m in messages)
+        {
+            var node = Node(m);
+            if (maxFieldChars > 0 && node is JsonObject obj)
+                foreach (var field in cappedFields)
+                {
+                    if (obj[field]?.GetValue<string>() is not { } text) continue;
+                    var truncated = text.Length > maxFieldChars;
+                    obj[field] = truncated ? text[..maxFieldChars] : text;
+                    obj[$"{field}Truncated"] = truncated;
+                }
+
+            arr.Add(node);
+            count++;
+        }
+
         return Indent(new JsonObject
         {
             ["messageCount"] = count,

--- a/src/LabVIEWMCP/Infra/ToolArguments.cs
+++ b/src/LabVIEWMCP/Infra/ToolArguments.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace LabVIEWMcp.Infra;
+
+/// <summary>
+/// The argument layer of the tool boundary: fold a near-miss spelling onto the schema's own, and
+/// turn a genuinely missing argument into data instead of a sentence that names nothing.
+///
+/// WHY THIS EXISTS - MEASURED 2026-08-14 by driving the built server over raw stdio with no client
+/// in between, reproducing issue #19. A call carrying `vi_path` instead of `viPath` answers:
+///     { "isError": true, "content": "An error occurred invoking 'lvai_describe_vi'." }
+/// The binding throws inside the SDK's AIFunctionMcpServerTool.InvokeAsync and McpServerImpl masks
+/// the exception to that sentence; the exception and its stack go to stderr, where no client looks.
+/// The issue blamed CLIENT-side schema validation, and so did the first reading of it here - it is
+/// OURS. That is the good news, because it means a server-side answer is possible at all.
+///
+/// The cost of not having this, from the same issue: nine identical failures, and a session spent
+/// on a LabVIEW-version hypothesis before anyone suspected a parameter name.
+///
+/// Two behaviours, applied in this order by <see cref="DiagnosingTool"/>:
+/// 1. FOLD - a key differing only in `_`, `-` or case is renamed to the schema's spelling, so a
+///    snake_case caller works. Measured in the same run: an unknown key is otherwise dropped in
+///    silence, which is why `vi_path` was indistinguishable from "no viPath given".
+/// 2. REPORT - a required key still absent afterwards returns <see cref="Json.Error"/> naming what
+///    is missing, what arrived, and every accepted name. One turn to recover instead of nine.
+/// </summary>
+internal static class ToolArguments
+{
+    /// <summary>
+    /// Case- and separator-insensitive form of an argument name. `vi_path`, `VI-Path` and `vipath`
+    /// all fold onto `viPath`'s fold, which is what makes one spelling stand for all of them.
+    /// </summary>
+    public static string Fold(string name) =>
+        name.Replace("_", "", StringComparison.Ordinal)
+            .Replace("-", "", StringComparison.Ordinal)
+            .ToLowerInvariant();
+
+    /// <summary>
+    /// The declared property names in schema order, and the subset the schema requires. A tool
+    /// with no parameters has neither, and must still pass through untouched.
+    /// </summary>
+    public static (List<string> Properties, List<string> Required) Shape(JsonElement schema)
+    {
+        var properties = new List<string>();
+        var required = new List<string>();
+
+        if (schema.ValueKind != JsonValueKind.Object) return (properties, required);
+
+        if (schema.TryGetProperty("properties", out var props) &&
+            props.ValueKind == JsonValueKind.Object)
+            foreach (var p in props.EnumerateObject())
+                properties.Add(p.Name);
+
+        if (schema.TryGetProperty("required", out var req) &&
+            req.ValueKind == JsonValueKind.Array)
+            foreach (var r in req.EnumerateArray())
+                if (r.GetString() is { } name)
+                    required.Add(name);
+
+        return (properties, required);
+    }
+
+    /// <summary>
+    /// Which supplied keys should be renamed to which declared name. A key that is already declared
+    /// is left alone, and so is one whose target the caller also supplied - overwriting a value the
+    /// caller spelled correctly would be worse than ignoring the stray key.
+    /// </summary>
+    public static Dictionary<string, string> Renames(
+        IReadOnlyCollection<string> properties, IReadOnlyCollection<string> supplied)
+    {
+        var renames = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (properties.Count == 0 || supplied.Count == 0) return renames;
+
+        // Ambiguity is possible in principle - two declared names could share a fold - and a guess
+        // between them would be worse than the generic error this class exists to remove.
+        var byFold = properties
+            .GroupBy(Fold, StringComparer.Ordinal)
+            .Where(g => g.Count() == 1)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        var declared = new HashSet<string>(properties, StringComparer.Ordinal);
+        foreach (var key in supplied)
+        {
+            if (declared.Contains(key)) continue;
+            if (byFold.TryGetValue(Fold(key), out var canonical) && !supplied.Contains(canonical))
+                renames[key] = canonical;
+        }
+
+        return renames;
+    }
+
+    /// <summary>Required names the caller did not supply. No arguments at all means all of them.</summary>
+    public static List<string> Missing(
+        IReadOnlyCollection<string> required, IReadOnlyCollection<string>? supplied) =>
+        [.. required.Where(r => supplied is null || !supplied.Contains(r))];
+
+    /// <summary>
+    /// The answer for a missing required argument: what is missing, what arrived, and the full list
+    /// of accepted names with their types - everything needed to fix the call in one turn.
+    /// </summary>
+    public static string MissingArguments(
+        string toolName, JsonElement schema,
+        IReadOnlyCollection<string> missing, IReadOnlyCollection<string> received)
+    {
+        var names = string.Join("', '", missing);
+        return Json.Error(
+            "badArguments",
+            $"{toolName} was called without the required argument{(missing.Count == 1 ? "" : "s")} " +
+            $"'{names}'.",
+            new
+            {
+                tool = toolName,
+                missing,
+                received,
+                accepted = Accepted(schema),
+                hint = "Argument names are camelCase and are listed under 'accepted'. A snake_case " +
+                       "or differently-cased spelling of a declared name is accepted and folded " +
+                       "onto it; a name that is not a declared one is ignored, which is what left " +
+                       "the argument above missing.",
+            });
+    }
+
+    /// <summary>
+    /// The answer for a call that reached the tool and failed there. In practice this is the SDK's
+    /// own binding failure - a wrong TYPE, mostly - because everything a tool body throws is already
+    /// turned into data by <see cref="Rpc.GuardAsync"/>. The exception message is the part the SDK
+    /// would have replaced with "An error occurred invoking '...'".
+    /// </summary>
+    public static string InvocationProblem(
+        string toolName, JsonElement schema, IReadOnlyCollection<string> received, Exception cause) =>
+        Json.Error(
+            "badArguments",
+            $"{toolName} could not be invoked with the arguments given: {cause.Message}",
+            new
+            {
+                tool = toolName,
+                received,
+                accepted = Accepted(schema),
+                exception = cause.GetType().Name,
+                hint = "Check each argument against 'accepted': a value of the wrong JSON type " +
+                       "fails here too. Numbers and paths are taken as the type shown, not as " +
+                       "whatever spelling looks natural.",
+            });
+
+    /// <summary>
+    /// Every declared argument as `name` -> `type, required` / `type, default x`, read out of the
+    /// tool's own schema so this can never drift from what is served.
+    /// </summary>
+    private static JsonObject Accepted(JsonElement schema)
+    {
+        var accepted = new JsonObject();
+        if (schema.ValueKind != JsonValueKind.Object ||
+            !schema.TryGetProperty("properties", out var props) ||
+            props.ValueKind != JsonValueKind.Object)
+            return accepted;
+
+        var (_, required) = Shape(schema);
+        foreach (var property in props.EnumerateObject())
+        {
+            var type = property.Value.TryGetProperty("type", out var t)
+                ? t.ValueKind == JsonValueKind.Array
+                    ? string.Join(" or ", t.EnumerateArray().Select(x => x.GetString()))
+                    : t.GetString()
+                : "unknown";
+
+            var suffix = required.Contains(property.Name)
+                ? ", required"
+                : property.Value.TryGetProperty("default", out var d)
+                    ? $", default {d.GetRawText()}"
+                    : ", optional";
+
+            accepted[property.Name] = $"{type}{suffix}";
+        }
+
+        return accepted;
+    }
+}

--- a/src/LabVIEWMCP/Program.cs
+++ b/src/LabVIEWMCP/Program.cs
@@ -100,7 +100,11 @@ builder.Services
     })
     .WithStdioServerTransport()
     .WithToolsFromAssembly()
-    .WithResourcesFromAssembly();
+    .WithResourcesFromAssembly()
+    // LAST, and it has to be: it wraps the tool registrations the line above just added. Without
+    // it a misspelled or missing argument answers "An error occurred invoking 'lvai_describe_vi'."
+    // and nothing else - our own masking, measured, not the client's. See Infra/ToolArguments.cs.
+    .WithArgumentDiagnostics();
 
 // Has NI's AI add-on been upgraded since last time? The AIXML export cache is keyed on the source
 // VI, which cannot see that the GENERATOR changed - so an add-on upgrade would leave entries built

--- a/src/LabVIEWMCP/Tools/InspectTools.cs
+++ b/src/LabVIEWMCP/Tools/InspectTools.cs
@@ -14,9 +14,15 @@ internal sealed class InspectTools(LvaiConnection connection)
     [Description("""
         RPC GetDescribeVIPromptInfo (server streaming). Returns a JSON description of a VI,
         including its AIXML representation under 'viXml' and, with getNodesInfo, the block
-        diagram nodes. This is the primary way to READ LabVIEW code as text.
-        The VI does not need to be open. Large VIs can take a while on first touch because
-        LabVIEW has to load them.
+        diagram nodes.
+        TO READ CODE, PREFER lvai_convert_vi_to_aixml: it carries the same diagram for a fraction
+        of the context, MEASURED on one VI in issue #19 at 17 532 bytes against 62 091 characters
+        here, and it is cached on disk for installation VIs where this call never is. Use this tool
+        for what it adds instead - the description, the controls and indicators, the subVI list and
+        the owning project - or cap the payload with maxContentChars.
+        The VI does not need to be open. FIRST TOUCH CAN BE SLOW, and slow here means minutes: a
+        class-member VI drags its whole hierarchy in, and it exceeded the 120 s default in issue #19.
+        Raise timeoutSeconds rather than concluding the VI or the server is broken.
         """)]
     public async Task<string> DescribeViAsync(
         [Description(@"Absolute path to the .vi file, e.g. C:\path\To\My.vi")] string viPath,
@@ -26,6 +32,8 @@ internal sealed class InspectTools(LvaiConnection connection)
         bool getNodesInfo = true,
         [Description("Max stream messages to collect")] int maxMessages = 10,
         [Description("Local budget in seconds")] int timeoutSeconds = 120,
+        [Description("Truncate each message's infoJson to this many characters (0 = unlimited)")]
+        int maxContentChars = 0,
         CancellationToken ct = default) =>
         await Rpc.GuardAsync(async () =>
         {
@@ -43,7 +51,9 @@ internal sealed class InspectTools(LvaiConnection connection)
 
                 var (items, reason) = await Rpc.CollectAsync(
                     call.ResponseStream, maxMessages, timeoutSeconds, t);
-                return Json.Stream(items, reason, maxMessages);
+                // infoJson is where the size is - it carries viXml, the nodes and the control list
+                // as one string - so that is the field a context budget has to be able to cap.
+                return Json.Stream(items, reason, maxMessages, maxContentChars, "infoJson");
             }, ct);
         });
 

--- a/tests/LabVIEWMCP.Tests/Infra/DiagnosingToolTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/DiagnosingToolTests.cs
@@ -1,0 +1,70 @@
+using LabVIEWMcp.Grpc;
+using LabVIEWMcp.Infra;
+using LabVIEWMcp.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Infra;
+
+/// <summary>
+/// That the wrapper actually reaches every served tool.
+///
+/// This is the half that cannot be argued from the schema: WithArgumentDiagnostics rewrites the
+/// service descriptors that WithToolsFromAssembly left behind, so it depends on the SDK registering
+/// tools as McpServerTool services. If a future SDK version registers them some other way, the loop
+/// finds nothing and the server quietly goes back to answering "An error occurred invoking '...'".
+/// That regression is invisible in production and obvious here.
+/// </summary>
+public class DiagnosingToolTests
+{
+    private static ServiceProvider ServedTools()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        // The tools take a connection; nothing here connects, and the port is never discovered
+        // because no call is made.
+        services.AddSingleton(provider => new LvaiConnection(
+            provider.GetRequiredService<ILogger<LvaiConnection>>(), 1));
+
+        services
+            .AddMcpServer()
+            // Explicitly the SERVER assembly: the argument-less overload would scan this test
+            // assembly instead and register nothing.
+            .WithToolsFromAssembly(typeof(InspectTools).Assembly)
+            .WithArgumentDiagnostics();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Every_served_tool_is_wrapped()
+    {
+        using var provider = ServedTools();
+
+        var tools = provider.GetServices<McpServerTool>().ToList();
+
+        // 41 tools on 2026-08-14. Asserted as a floor rather than an equality so that adding a tool
+        // is not a test failure, while losing the registration wholesale still is.
+        Assert.True(tools.Count >= 41, $"only {tools.Count} tools registered");
+        Assert.All(tools, tool => Assert.IsType<DiagnosingTool>(tool));
+    }
+
+    /// <summary>
+    /// The wrapper reads the inner tool's name and schema to build its report, so the delegation of
+    /// ProtocolTool is load-bearing rather than incidental.
+    /// </summary>
+    [Fact]
+    public void The_wrapper_still_serves_the_inner_name_and_schema()
+    {
+        using var provider = ServedTools();
+
+        var describe = provider.GetServices<McpServerTool>()
+            .Single(tool => tool.ProtocolTool.Name == "lvai_describe_vi");
+
+        var (properties, required) = ToolArguments.Shape(describe.ProtocolTool.InputSchema);
+        Assert.Contains("viPath", properties);
+        Assert.Equal(["viPath"], required);
+    }
+}

--- a/tests/LabVIEWMCP.Tests/Infra/JsonTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/JsonTests.cs
@@ -96,6 +96,54 @@ public class JsonStreamTests
         Assert.Equal("timeout", Res.Str(result, "stopReason"));
         Assert.Empty(Res.Arr(result, "messages"));
     }
+
+    /// <summary>
+    /// The cap exists because lvai_describe_vi answered 62 091 characters for a VI whose whole AIXML
+    /// is 17 532 bytes (issue #19), and infoJson is where that size sits. Same shape as the AIXML
+    /// tools' `xml` / `xmlTruncated` pair, so a caller who knows one knows the other.
+    /// </summary>
+    [Fact]
+    public void A_capped_field_is_truncated_and_says_so()
+    {
+        var messages = new[]
+        {
+            new GetDescribeVIPromptInfoResponse { InfoJson = new string('x', 100) },
+        };
+
+        var result = Json.Stream(messages, "stream completed", 10, 10, "infoJson");
+
+        var message = Res.Arr(result, "messages")[0]!;
+        Assert.Equal(10, message["infoJson"]!.GetValue<string>().Length);
+        Assert.True(message["infoJsonTruncated"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void A_field_under_the_cap_is_whole_and_flagged_false()
+    {
+        var messages = new[] { new GetDescribeVIPromptInfoResponse { InfoJson = "short" } };
+
+        var result = Json.Stream(messages, "stream completed", 10, 1000, "infoJson");
+
+        var message = Res.Arr(result, "messages")[0]!;
+        Assert.Equal("short", message["infoJson"]!.GetValue<string>());
+        Assert.False(message["infoJsonTruncated"]!.GetValue<bool>());
+    }
+
+    /// <summary>
+    /// Zero means unlimited, and it is the default - so the three-argument overload and an explicit
+    /// 0 must both leave the message exactly as it arrived, flag included.
+    /// </summary>
+    [Fact]
+    public void A_cap_of_zero_leaves_the_message_untouched()
+    {
+        var messages = new[] { new GetDescribeVIPromptInfoResponse { InfoJson = new string('x', 99) } };
+
+        var result = Json.Stream(messages, "stream completed", 10, 0, "infoJson");
+
+        var message = Res.Arr(result, "messages")[0]!;
+        Assert.Equal(99, message["infoJson"]!.GetValue<string>().Length);
+        Assert.Null(message["infoJsonTruncated"]);
+    }
 }
 
 public class JsonErrorTests

--- a/tests/LabVIEWMCP.Tests/Infra/ToolArgumentsTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/ToolArgumentsTests.cs
@@ -1,0 +1,194 @@
+using System.Text.Json;
+using LabVIEWMcp.Infra;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Infra;
+
+/// <summary>
+/// The argument layer that removes "An error occurred invoking 'lvai_describe_vi'." (issue #19).
+///
+/// THE SCHEMA FIXTURE IS A MEASUREMENT: it is what `tools/list` served for lvai_describe_vi on
+/// 2026-08-14, read off the wire, plus the maxContentChars parameter added in the same change. It is
+/// a fixture rather than a live read because these tests are about the mechanics of folding and
+/// reporting - the wiring that a real schema reaches them is asserted in DiagnosingToolTests.
+/// </summary>
+public class ToolArgumentsTests
+{
+    private const string DescribeViSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "viPath": { "description": "Absolute path to the .vi file", "type": "string" },
+            "viName": { "description": "Optional VI name", "type": ["string", "null"],
+                        "default": null },
+            "getNodesInfo": { "description": "Include nodes", "type": "boolean", "default": true },
+            "maxMessages": { "description": "Max stream messages", "type": "integer",
+                             "default": 10 },
+            "timeoutSeconds": { "description": "Local budget", "type": "integer", "default": 120 },
+            "maxContentChars": { "description": "Truncate infoJson", "type": "integer",
+                                 "default": 0 }
+          },
+          "required": [ "viPath" ]
+        }
+        """;
+
+    private static JsonElement Schema(string json = DescribeViSchema) =>
+        JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void Shape_reads_properties_and_required()
+    {
+        var (properties, required) = ToolArguments.Shape(Schema());
+
+        Assert.Equal(
+            ["viPath", "viName", "getNodesInfo", "maxMessages", "timeoutSeconds", "maxContentChars"],
+            properties);
+        Assert.Equal(["viPath"], required);
+    }
+
+    /// <summary>A tool with no parameters at all - lvai_status - must not trip over an empty schema.</summary>
+    [Fact]
+    public void Shape_tolerates_an_empty_schema()
+    {
+        var (properties, required) = ToolArguments.Shape(Schema("""{ "type": "object" }"""));
+
+        Assert.Empty(properties);
+        Assert.Empty(required);
+    }
+
+    [Theory]
+    [InlineData("vi_path")]
+    [InlineData("VI_PATH")]
+    [InlineData("vi-path")]
+    [InlineData("vipath")]
+    [InlineData("ViPath")]
+    public void Fold_makes_near_misses_equal(string spelling) =>
+        Assert.Equal(ToolArguments.Fold("viPath"), ToolArguments.Fold(spelling));
+
+    [Fact]
+    public void Fold_keeps_distinct_names_distinct() =>
+        Assert.NotEqual(ToolArguments.Fold("viPath"), ToolArguments.Fold("viPaths"));
+
+    /// <summary>The case out of issue #19, and the reason this class exists.</summary>
+    [Fact]
+    public void Snake_case_is_renamed_to_the_schema_spelling()
+    {
+        var (properties, _) = ToolArguments.Shape(Schema());
+
+        var renames = ToolArguments.Renames(properties, ["vi_path", "timeout_seconds"]);
+
+        Assert.Equal("viPath", renames["vi_path"]);
+        Assert.Equal("timeoutSeconds", renames["timeout_seconds"]);
+    }
+
+    [Fact]
+    public void A_correctly_spelled_key_is_left_alone()
+    {
+        var (properties, _) = ToolArguments.Shape(Schema());
+
+        Assert.Empty(ToolArguments.Renames(properties, ["viPath", "getNodesInfo"]));
+    }
+
+    /// <summary>
+    /// Both spellings supplied: the declared one wins and the stray key is left where it is.
+    /// Renaming here would overwrite a value the caller spelled correctly, which is worse than the
+    /// silence this whole change is removing - measured, an undeclared key is simply ignored.
+    /// </summary>
+    [Fact]
+    public void A_declared_key_is_never_overwritten_by_its_variant()
+    {
+        var (properties, _) = ToolArguments.Shape(Schema());
+
+        Assert.Empty(ToolArguments.Renames(properties, ["viPath", "vi_path"]));
+    }
+
+    [Fact]
+    public void A_key_that_matches_nothing_is_not_renamed()
+    {
+        var (properties, _) = ToolArguments.Shape(Schema());
+
+        Assert.Empty(ToolArguments.Renames(properties, ["path", "file"]));
+    }
+
+    /// <summary>
+    /// Two declared names sharing a fold cannot both be the target, so neither is: a guess between
+    /// them would be exactly the kind of invisible wrong answer this class replaces.
+    /// </summary>
+    [Fact]
+    public void An_ambiguous_fold_is_not_guessed()
+    {
+        var ambiguous = Schema("""
+            {
+              "type": "object",
+              "properties": { "viPath": { "type": "string" }, "vi_path": { "type": "string" } },
+              "required": [ "viPath" ]
+            }
+            """);
+        var (properties, _) = ToolArguments.Shape(ambiguous);
+
+        Assert.Empty(ToolArguments.Renames(properties, ["VIPATH"]));
+    }
+
+    [Fact]
+    public void Missing_is_empty_when_the_required_key_is_there()
+    {
+        var (_, required) = ToolArguments.Shape(Schema());
+
+        Assert.Empty(ToolArguments.Missing(required, ["viPath", "getNodesInfo"]));
+    }
+
+    [Fact]
+    public void Missing_names_the_required_key_that_is_absent()
+    {
+        var (_, required) = ToolArguments.Shape(Schema());
+
+        Assert.Equal(["viPath"], ToolArguments.Missing(required, ["getNodesInfo"]));
+        Assert.Equal(["viPath"], ToolArguments.Missing(required, supplied: null));
+    }
+
+    /// <summary>
+    /// The report has to carry three things to be actionable in one turn: what is missing, what the
+    /// caller actually sent, and what the accepted names are.
+    /// </summary>
+    [Fact]
+    public void Missing_arguments_reports_missing_received_and_accepted()
+    {
+        var json = ToolArguments.MissingArguments(
+            "lvai_describe_vi", Schema(), ["viPath"], ["vi_path"]);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("badArguments", root.GetProperty("errorKind").GetString());
+        Assert.Contains("viPath", root.GetProperty("error").GetString());
+
+        var detail = root.GetProperty("detail");
+        Assert.Equal("lvai_describe_vi", detail.GetProperty("tool").GetString());
+        Assert.Equal("viPath", detail.GetProperty("missing")[0].GetString());
+        Assert.Equal("vi_path", detail.GetProperty("received")[0].GetString());
+
+        var accepted = detail.GetProperty("accepted");
+        Assert.Equal("string, required", accepted.GetProperty("viPath").GetString());
+        Assert.Equal("integer, default 120", accepted.GetProperty("timeoutSeconds").GetString());
+        Assert.Equal("string or null, default null", accepted.GetProperty("viName").GetString());
+        Assert.Contains("camelCase", detail.GetProperty("hint").GetString());
+    }
+
+    /// <summary>
+    /// A wrong TYPE fails in the SDK's binding, not in the tool body, and the message it throws is
+    /// exactly what the server would otherwise replace with "An error occurred invoking '...'".
+    /// </summary>
+    [Fact]
+    public void Invocation_problem_keeps_the_exception_message()
+    {
+        var json = ToolArguments.InvocationProblem(
+            "lvai_describe_vi", Schema(), ["viPath", "timeoutSeconds"],
+            new ArgumentException("'timeoutSeconds' could not be converted to Int32."));
+
+        using var doc = JsonDocument.Parse(json);
+        var detail = doc.RootElement.GetProperty("detail");
+        Assert.Contains("could not be converted", doc.RootElement.GetProperty("error").GetString());
+        Assert.Equal("ArgumentException", detail.GetProperty("exception").GetString());
+        Assert.Equal("string, required", detail.GetProperty("accepted").GetProperty("viPath").GetString());
+    }
+}


### PR DESCRIPTION
"An error occurred invoking 'lvai_...'" is our own masking, not the client-side validation issue #19 concluded - measured over raw stdio with no client. An undeclared key is dropped silently, so `vi_path` looked like no argument at all.