### PR TITLE
Validate release tags and make every install say which version it is

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,15 @@ name: release
 # Tag a commit v1.2.3 and push the tag to cut a release. The job runs on Windows because
 # the server is win-x64 only, publishes the self-contained single-file exe, packs it into
 # the plugin staging tree, and attaches the zip to the GitHub Release under a FIXED asset
-# name. The marketplace manifest points at
+# name.
+#
+# THE TAG MUST BE vX.Y.Z, lower-case, three numeric components. scripts\Assert-ReleaseTag.ps1
+# is the first step and refuses anything else with a diagnosis and the retag commands; the tag
+# is then stamped into the exe's version resource, plugin.json's `version` and VERSION.txt at
+# the archive root, so an install can say what it is. Three further assets go alongside the
+# fixed-name zip: a version-named copy of it, its SHA-256, and a per-file manifest.
+#
+# The marketplace manifest points at
 #   https://github.com/Zuehlke/labview-mcp/releases/latest/download/labview-mcp.zip
 # so the manifest never needs editing after a release: GitHub redirects /releases/latest/
 # to the newest published release, and the archive's own digest is the plugin version, so
@@ -28,6 +36,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # 0. THE TAG IS THE VERSION, so refuse a tag that cannot be one - FIRST, before the test
+      #    run, so a mistyped tag costs seconds instead of ten minutes and publishes nothing.
+      #
+      #    The tags in this repository did not agree on a format: v1.3.0, v1.1.1 and v1.0.7 are
+      #    lower-case, V1.2.8/V1.2.5/V1.2.2/V1.2.0/V1.1.5 are upper-case, and v10.4 has two
+      #    components - which also sorts ABOVE every three-part tag in
+      #    `git tag --sort=-v:refname`, so the newest-looking tag in the list was for ten days
+      #    neither the newest release nor a valid version.
+      #
+      #    The script prints the diagnosis and the delete-and-retag commands; it also parses the
+      #    tag into steps.tag.outputs.version for the stamping steps below. A maintainer can run
+      #    it locally before pushing, which is the point at which it is cheapest to be told.
+      - name: Validate the release tag
+        id: tag
+        shell: pwsh
+        run: |
+          powershell -ExecutionPolicy Bypass -File scripts/Assert-ReleaseTag.ps1 -Tag "${{ github.ref_name }}"
+          exit $LASTEXITCODE
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -47,7 +74,7 @@ jobs:
       - name: Build Release and verify embedded documentation
         shell: pwsh
         run: |
-          dotnet build $env:PROJECT -c Release --nologo -v quiet
+          dotnet build $env:PROJECT -c Release --nologo -v quiet -p:Version=${{ steps.tag.outputs.version }}
           if ($LASTEXITCODE -ne 0) { throw "Release build failed" }
           powershell -ExecutionPolicy Bypass -File build.ps1 -VerifyOnly -Configuration Release
           if ($LASTEXITCODE -ne 0) { throw "Embedded-documentation verification failed" }
@@ -56,6 +83,14 @@ jobs:
       #    for self-extract, and PublishTrimmed=false. Trimming strips the protobuf/gRPC
       #    reflection metadata the schema-recovery path depends on, and the failure only shows
       #    up at runtime as an empty schema dump — so trimming must stay off.
+      #
+      #    -p:Version stamps the tag into the Win32 version resource, so the exe names the release
+      #    it came from in Explorer → Properties → Details and through `--version`. The csproj
+      #    default is 0.0.0, which marks a build that did NOT come from here. Until 2026-09-11
+      #    nothing set it, so every release ever published carried the SDK default 1.0.0 and was
+      #    indistinguishable from a local debug build; identifying an install meant hashing 800
+      #    files. The commit SHA was already present - the SDK appends SourceRevisionId to
+      #    InformationalVersion - so only the semantic half was missing.
       - name: Publish (win-x64, self-contained, single file, NOT trimmed)
         shell: pwsh
         run: |
@@ -66,9 +101,19 @@ jobs:
             -p:PublishSingleFile=true `
             -p:IncludeNativeLibrariesForSelfExtract=true `
             -p:PublishTrimmed=false `
+            -p:Version=${{ steps.tag.outputs.version }} `
             -o publish
           if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed" }
           if (-not (Test-Path publish/LabVIEWMCP.exe)) { throw "publish/LabVIEWMCP.exe missing after publish" }
+
+          # Assert the stamp actually landed. `-p:Version=` is silently ignored if the property is
+          # overridden later in the build, and the failure would otherwise ship: an exe reporting
+          # 0.0.0 from a tagged release looks exactly like a dev build to every later check.
+          $stamped = (Get-Item publish/LabVIEWMCP.exe).VersionInfo.ProductVersion
+          Write-Host "stamped ProductVersion: $stamped"
+          if (-not $stamped.StartsWith("${{ steps.tag.outputs.version }}")) {
+            throw "the published exe reports '$stamped' but the tag is ${{ github.ref_name }} - the version stamp did not take"
+          }
 
       # 3b. Assemble the pylabview bundle.
       #
@@ -187,6 +232,79 @@ jobs:
           $bundleMB = [math]::Round(($bundleFiles | Measure-Object Length -Sum).Sum / 1MB, 1)
           Write-Host "  \bin\pylabview  ($($bundleFiles.Count) files, $bundleMB MB)"
 
+      # 4b. Make the ARTEFACT self-identifying, which the exe's version resource alone does not.
+      #
+      #     Two separate things, for two separate readers:
+      #
+      #     VERSION.txt at the archive root, because a FILE NAME dies at extraction. That is not
+      #     hypothetical: on 2026-09-11 a hand-extracted install at C:\Projects\labview-mcp could
+      #     not say what it was, and identifying it needed the exe's embedded commit SHA resolved
+      #     against `git describe`. A plain key/value file survives extraction, is greppable, needs
+      #     nothing to be running, and answers even when the exe will not start. It also carries
+      #     the TAG, which the assembly cannot: the assembly knows 1.3.0, not that it came from
+      #     `v1.3.0`.
+      #
+      #     plugin.json's `version`, because that is what `claude plugin list` and
+      #     `claude plugin details` read. The repository file carries the 0.0.0 placeholder so the
+      #     key's presence and position are reviewable in-repo; only the value is injected here.
+      #     A targeted string replacement rather than ConvertFrom-Json/ConvertTo-Json, so the rest
+      #     of the file - including the non-ASCII author name - stays byte-for-byte what was
+      #     reviewed.
+      - name: Stamp the version into the staging tree
+        shell: pwsh
+        run: |
+          $version = '${{ steps.tag.outputs.version }}'
+          $tag     = '${{ steps.tag.outputs.tag }}'
+
+          $lines = @(
+            "tag: $tag",
+            "version: $version",
+            "commit: ${{ github.sha }}",
+            "built: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))",
+            "run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          )
+          $versionFile = 'staging/VERSION.txt'
+          [IO.File]::WriteAllText($versionFile, ($lines -join "`n") + "`n",
+                                  [Text.UTF8Encoding]::new($false))
+          Write-Host "VERSION.txt:"
+          Get-Content $versionFile | ForEach-Object { Write-Host "  $_" }
+
+          # Encoding stated explicitly on every read and write. plugin.json holds a non-ASCII
+          # author name, and `Get-Content` decodes a BOM-less file with the system ANSI codepage
+          # on Windows PowerShell while `pwsh` uses UTF-8 - so a step that relies on the host
+          # default turns "Zühlke" into "ZÃ¼hlke" depending on which shell ran it. Measured while
+          # dry-running this step locally: the bytes on disk were right and the VERIFICATION was
+          # wrong, which is the failure that would have shipped a mojibake manifest one day.
+          $utf8 = [Text.UTF8Encoding]::new($false)
+          $manifestPath = 'staging/.claude-plugin/plugin.json'
+          $before = [IO.File]::ReadAllText($manifestPath, $utf8)
+          $after = $before -replace '"version"\s*:\s*"0\.0\.0"', ('"version": "' + $version + '"')
+          if ($after -eq $before) {
+            throw ("$manifestPath does not contain the `"version`": `"0.0.0`" placeholder, so the " +
+                   "release version could not be injected. Restore the placeholder in " +
+                   "plugin/.claude-plugin/plugin.json - a plugin with no version is one " +
+                   "`claude plugin list` cannot identify, which is the whole reason it is there.")
+          }
+          [IO.File]::WriteAllText($manifestPath, $after, $utf8)
+
+          # Read it back through a JSON parser: a replacement that produced invalid JSON would make
+          # the plugin uninstallable, and the string substitution above cannot tell.
+          $parsed = [IO.File]::ReadAllText($manifestPath, $utf8) | ConvertFrom-Json
+          if ($parsed.version -ne $version) {
+            throw "plugin.json reports version '$($parsed.version)' after stamping, expected '$version'"
+          }
+
+          # And that what reached disk is EXACTLY what we meant to write. plugin.json holds a
+          # non-ASCII author name, and a re-encode would leave valid JSON carrying a mangled
+          # string - so the parser above cannot see it, and the damage would surface only in the
+          # plugin's own listing. Compared as decoded bytes against $after rather than against a
+          # literal, so this assertion carries no non-ASCII text of its own to go wrong.
+          $roundTrip = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($manifestPath))
+          if ($roundTrip -ne $after) {
+            throw "plugin.json on disk is not byte-identical to the stamped text - it was re-encoded"
+          }
+          Write-Host "OK: plugin.json version = $($parsed.version), encoding intact"
+
       # 5. The manifest is what makes the zip installable. Fail loudly if it is not at the root.
       - name: Assert plugin manifest is at the staging root
         shell: pwsh
@@ -304,6 +422,25 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "LabVIEWMCP.exe --help exited $LASTEXITCODE (expected 0)" }
           Write-Host "OK: --help exited 0"
 
+      # 6b. --version, from the exe IN THE STAGING TREE, so this also proves VERSION.txt is where
+      #     the exe looks for it (<exe dir>\..\VERSION.txt) rather than merely present somewhere.
+      #     Asserting the OUTPUT, not just the exit code: the version resource is read at run time
+      #     through reflection, and an exe that starts fine can still report 0.0.0.
+      - name: Smoke-test the packaged exe (--version reports the tag)
+        shell: pwsh
+        run: |
+          $out = & staging/bin/LabVIEWMCP.exe --version
+          if ($LASTEXITCODE -ne 0) { throw "LabVIEWMCP.exe --version exited $LASTEXITCODE (expected 0)" }
+          $out | ForEach-Object { Write-Host "  $_" }
+          $text = $out -join "`n"
+          foreach ($want in @('${{ steps.tag.outputs.version }}', '${{ steps.tag.outputs.tag }}', '${{ github.sha }}')) {
+            if ($text -notlike "*$want*") {
+              throw "--version output does not mention '$want' - the stamp or VERSION.txt did not reach the exe"
+            }
+          }
+          if ($text -like '*-dev*') { throw "--version reports a dev build from a tagged release" }
+          Write-Host "OK: --version reports the tag, the version and the commit"
+
       # 7. Zip the staging CONTENTS so .claude-plugin/plugin.json sits at the zip root, then
       #    attach it to the Release under the fixed asset name the marketplace manifest expects.
       - name: Zip the staging tree
@@ -327,10 +464,60 @@ jobs:
           if ($names -notcontains '.claude-plugin/plugin.json') {
             throw ".claude-plugin/plugin.json is not at the zip root"
           }
-          Write-Host "OK: .claude-plugin/plugin.json is at the zip root"
+          if ($names -notcontains 'VERSION.txt') {
+            throw "VERSION.txt is not at the zip root - an extracted install could not identify itself"
+          }
+          Write-Host "OK: .claude-plugin/plugin.json and VERSION.txt are at the zip root"
 
-      - name: Attach the zip to the release
+      # 7b. Three more assets, none of which may replace the fixed-name zip above.
+      #
+      #     labview-mcp-<tag>.zip  - the SAME bytes under a self-identifying name. The fixed name
+      #       is load-bearing: .claude-plugin/marketplace.json points at
+      #       releases/latest/download/labview-mcp.zip, which is why the manifest never needs
+      #       editing after a release. So the versioned copy is an ADDITION, for the human who
+      #       downloads from the Releases page and later wants to know what they extracted.
+      #
+      #     labview-mcp.sha256  - the archive's own digest, so a download can be checked.
+      #
+      #     labview-mcp.manifest.sha256  - relative path plus SHA-256 of EVERY file in the
+      #       archive. This is the one that answers "is my install intact and complete?" without a
+      #       second install to diff against - which on 2026-09-11 was the only way to settle a
+      #       report that the plugin route shipped less than the zip route (it does not: same
+      #       archive, 732 files, every hash equal - the reported difference was a three-release
+      #       stale plugin cache). scripts\Compare-Installs.ps1 -ManifestPath consumes it.
+      - name: Publish the version-named copy, the digest and the file manifest
+        shell: pwsh
+        run: |
+          $tag = '${{ steps.tag.outputs.tag }}'
+          Copy-Item $env:ASSET_NAME "labview-mcp-$tag.zip" -Force
+
+          $hash = (Get-FileHash $env:ASSET_NAME -Algorithm SHA256).Hash.ToLowerInvariant()
+          # Two spaces then the name: the `sha256sum -c` format, so this is checkable with the
+          # tool people already have rather than only by eye.
+          [IO.File]::WriteAllText('labview-mcp.sha256', "$hash  $env:ASSET_NAME`n",
+                                  [Text.UTF8Encoding]::new($false))
+          Write-Host "archive sha256: $hash"
+
+          # Hashed from the STAGING TREE, whose bytes are what went into the archive. Sorted, so
+          # two releases' manifests diff meaningfully.
+          $root = (Resolve-Path 'staging').Path
+          $rows = Get-ChildItem $root -Recurse -File -Force | ForEach-Object {
+            $rel = $_.FullName.Substring($root.Length).TrimStart('\').Replace('\', '/')
+            "$((Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant())  $rel"
+          } | Sort-Object
+          [IO.File]::WriteAllText('labview-mcp.manifest.sha256', (($rows -join "`n") + "`n"),
+                                  [Text.UTF8Encoding]::new($false))
+          Write-Host "file manifest: $($rows.Count) entries"
+
+      - name: Attach the assets to the release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.ASSET_NAME }}
+          # The fixed name FIRST and always: the marketplace resolves
+          # /releases/latest/download/labview-mcp.zip, so a release missing it is a release no
+          # plugin install can fetch.
+          files: |
+            ${{ env.ASSET_NAME }}
+            labview-mcp-${{ steps.tag.outputs.tag }}.zip
+            labview-mcp.sha256
+            labview-mcp.manifest.sha256
           fail_on_unmatched_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1348,6 +1348,8 @@ literally it argued away 600 usable palette VIs.
 | How do I repoint many subVI nodes or class constants? | `docs/labview-unit-testing.md` §3d | `lvai_swap_subvis` |
 | How do I generate several VIs from AIXML at once? | `docs/bulk-operations.md` | `lvai_generate_vis` |
 | Why did a tool call fail with no detail? | `docs/tool-argument-errors.md` | — |
+| WHICH RELEASE is this install, and do the plugin and the zip differ? | `docs/release-versioning.md` | `LabVIEWMCP --version`, `lvai_status`/`pylv_status` (`serverVersion`), `scripts/Compare-Installs.ps1` |
+| What must a release TAG look like? | `docs/release-versioning.md` §4 | `scripts/Assert-ReleaseTag.ps1` |
 | How do I generate a VI in one call? | `docs/bulk-operations.md` | `lvai_generate_vi` |
 | How do I run a whole pylabview edit in one call? | `docs/bulk-operations.md` | `pylv_apply` |
 | When is pylabview the route, not AIXML? | `experiments/pylabview/ROUTING.md` (source tree only) | `pylv_route` |
@@ -1510,6 +1512,35 @@ Measured twice on 2026-09-07: 1 627 648 bytes against 2 592 768, and `build.ps1`
 embedded agent definitions were missing, which is 40-odd failing tests pointing everywhere except
 at the cause. `-t:Compile` skips the resource-preparation targets; a redirected
 `BaseIntermediateOutputPath` collides with the generated protobuf and `AssemblyInfo`.
+
+**A RELEASE TAG IS `vX.Y.Z`, lower-case, three decimal components — and `scripts/Assert-ReleaseTag.ps1`
+is the first step of the release workflow so a bad one publishes nothing.** Check a tag *before*
+pushing it: `-Tag v1.4.0` costs a second and the refusal names the mistake, the intended tag and the
+retag commands. The rule exists because the tags did not agree: measured 2026-09-11, five of nine
+were upper-case `V` — which git treats as a *different ref* and the `v*` trigger therefore ignores
+outright — and `v10.4` had two components, which additionally sorts ABOVE every three-part tag in
+`git tag --sort=-v:refname`, so for ten days the newest-looking tag in the list was neither the
+newest release nor a valid version.
+
+**AND THE TAG IS THE ONLY THING THAT NAMES A BUILD, so do not hand-cut a release.** `<Version>` in
+the csproj is `0.0.0` — the marker for "not from the workflow" — and only `dotnet publish
+-p:Version=` stamps a real one. Until 2026-09-11 nothing set it at all, so every release ever
+published carried the SDK default `1.0.0` and was indistinguishable from a local debug build:
+identifying an install meant hashing 800 files. The commit SHA had been embedded the whole time
+(the SDK appends `SourceRevisionId` to `InformationalVersion`), which is the lesson worth keeping —
+**a value that exists but is not reported is not an answer**, the same shape as an embedded document
+nothing serves. It is now reported by `--version`, by `lvai_status` and by `pylv_status`, that last
+one because it is the only one that answers with no LabVIEW running.
+
+**THE PLUGIN AND THE RELEASE ZIP ARE THE SAME BYTES — stop looking for a packaging difference.**
+`.claude-plugin/marketplace.json` declares the plugin as an `archive` source pointing at
+`releases/latest/download/labview-mcp.zip`, so a store install IS that asset unpacked: one build,
+one packaging path. Measured over one tag, 732 files, every SHA-256 equal, the pylabview bundle
+byte-for-byte identical. A reported behaviour difference is **version skew**, and the usual cause is
+that a marketplace catalogue does not refresh itself — one 13 days stale was serving a copy three
+releases behind. `claude plugin marketplace update` then `claude plugin update`. The one real
+asymmetry is extraction: Explorer's "Extract All" propagates Mark-of-the-Web onto the bundled
+`python.exe`, so extract with `tar -xf`.
 
 **The recovery is `rm -rf src/LabVIEWMCP/obj src/LabVIEWMCP/bin tests/LabVIEWMCP.Tests/obj
 tests/LabVIEWMCP.Tests/bin` and a normal build.** If you want a type-check while the server holds

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-> $${\color{orange}\Large\textsf{There is currently a problem with the installer.}}$$
-> $${\color{orange}\Large\textsf{Please use the repository or the ZIP file for the tag directly!}}$$
-> $${\color{orange}\Large\textsf{We apologise for the inconvenience!}}$$
->
->
 > ## 🧪 Read this before you let a robot touch your VIs
 >
 > **Not affiliated with, endorsed by, or supported by NI or Emerson.** Nobody at NI asked for
@@ -635,11 +630,50 @@ install has no repository root.
 What still has to exist on the target machine: LabVIEW with its AI feature, the .NET 8 runtime,
 and — only for the documentation generator — `python-docx` and a Chromium browser.
 
+### Which version am I running?
+
+Four places answer it, in descending order of convenience:
+
+```powershell
+LabVIEWMCP.exe --version              # version, commit, exe path, and the archive's VERSION.txt
+Get-Content <install root>\VERSION.txt # tag, version, commit, build time, workflow run
+claude plugin list                     # the plugin's version, from plugin.json
+```
+
+and from inside a session, `lvai_status` or — with **no LabVIEW running** — `pylv_status`, both of
+which report `serverVersion` and `serverCommit`.
+
+A version of `0.0.0-dev` means the exe was not built by the release workflow. On an install from
+**before v1.3.1** none of the above exists, and the only identifier is the commit the .NET SDK has
+always embedded:
+
+```powershell
+(Get-Item <install root>\bin\LabVIEWMCP.exe).VersionInfo.ProductVersion
+```
+
+which gives `<version>+<sha>`; `git describe --tags --exact-match <sha>` names the release. Every
+release before v1.3.1 reports version `1.0.0`, because the project set none — so on those copies the
+SHA is the *only* thing that distinguishes them.
+
+**The plugin install and the Releases-page download are the same bytes**, by construction: the
+marketplace declares the plugin as an `archive` source pointing at
+`/releases/latest/download/labview-mcp.zip`. Measured over one tag, 732 files, every hash equal,
+the pylabview bundle included. If two installs behave differently, compare what release each one
+reports before suspecting the packaging — and verify either one against the release's own manifest:
+
+```powershell
+.\scripts\Compare-Installs.ps1 -PluginRoot <install root> -ManifestPath .\labview-mcp.manifest.sha256
+```
+
+[`docs/release-versioning.md`](docs/release-versioning.md) has the measurements.
+
 ### Troubleshooting
 
 | Symptom | Cause and fix |
 |---|---|
 | Server does not appear at all | Config not loaded — restart Claude Code. For project scope, confirm you approved it. |
+| The plugin install seems to have **less** than the zip download — fewer agents, missing scripts, `pylv_*` unusable | Not a packaging difference: both routes take the same archive. It is a **stale marketplace catalogue** — it does not refresh on demand, so `claude plugin install` can fetch an archive several releases old. Measured 2026-09-11: a catalogue last updated 13 days earlier was serving a copy three releases behind, missing 5 of the 8 agents and all of `bin\claude\`. Fix with `claude plugin marketplace update zuehlke-labview` then `claude plugin update labview-mcp`, and restart. Confirm with `LabVIEWMCP.exe --version` on each install. |
+| A manually extracted install misbehaves — `python.exe` prompts, or the bundle fails to import | Explorer's "Extract All" propagates the Mark-of-the-Web `Zone.Identifier` stream onto every extracted file. Extract with `tar -xf labview-mcp.zip -C <dir>` (`tar` ships in `System32` on Windows 10+), or check with `Get-Item -Stream Zone.Identifier` and `Unblock-File`. |
 | Every `pylv_*` tool answers `notProvisioned` | The 38 MB pylabview bundle is not beside the exe. On a plugin or zip install that means the install predates **v0.9.2**, the first release to carry it (the asset went from 32 MB to 49 MB): `claude plugin update labview-mcp`, or re-extract the latest `labview-mcp.zip`, then restart the client. In a checkout, run `tools\pylabview\provision.ps1`. `LabVIEWMCP.exe --pylv-status` answers in one line from either, and `LABVIEWMCP_PYLABVIEW` points at a bundle kept elsewhere. |
 | Server fails to start | The `command` path is wrong or unbuilt. Run the `.exe` in a terminal: it should log two `info:` lines to stderr ("transport reading messages", "Application started") and then wait on stdin. Anything else is the real error. |
 | `ok: false`, `InvalidOperationException`, "Could not find a port serving lvai.LVAI" | LabVIEW is not running, or its AI feature is off. The message lists every port that was probed. |
@@ -920,42 +954,68 @@ git tag v0.9.0        # lowercase v + semver — this is the convention
 git push origin v0.9.0
 ```
 
-The tag must be a **lowercase `v`** followed by the version (`v0.9.0`, `v1.2.3`). The workflow
-triggers only on tags matching `v*`, and GitHub matches that **case-sensitively**, so an uppercase
-`V0.9.0` is silently ignored and no release is built.
+The tag must be **`vX.Y.Z`** — a lowercase `v` and exactly three decimal numbers. Check it before
+you push, which is the cheapest moment to be told:
 
-This is not hypothetical: `V0.8.5` was tagged uppercase, built nothing, was cut by hand instead —
-and since `/releases/latest/` follows the newest **published** release whether the workflow built it
-or not, that broke `claude plugin update` with a 404 for everyone until `v0.8.6` was cut from the
-same commit. Never publish a release by hand.
+```bash
+powershell -ExecutionPolicy Bypass -File scripts/Assert-ReleaseTag.ps1 -Tag v1.4.0
+```
+
+The workflow runs the same script as its **first** step and refuses anything else with a diagnosis
+naming the actual mistake, the probable intended tag, and the delete-and-retag commands — so a bad
+tag costs seconds instead of a ten-minute build, and publishes nothing.
+
+Each refused shape is a distinct hazard. An uppercase `V0.9.0` is silently ignored, because the
+workflow triggers on `v*` and GitHub matches that **case-sensitively** — not hypothetical: `V0.8.5`
+was tagged uppercase, built nothing, was cut by hand instead, and since `/releases/latest/` follows
+the newest **published** release whether the workflow built it or not, that broke
+`claude plugin update` with a 404 for everyone until `v0.8.6` was cut from the same commit. Never
+publish a release by hand. A two-part tag such as `v10.4` also sorts **above** every three-part tag
+in `git tag --sort=-v:refname`, so it masks the real newest release in every listing. And a leading
+zero (`v1.02.3`) is refused because MSBuild reads `02` as `2`, so the tag and its zero-free twin
+would stamp an identical version into every artefact while remaining different git refs. The whole
+table is in [`docs/release-versioning.md`](docs/release-versioning.md) §4.
 
 On the tag push, the workflow runs on `windows-latest` and:
 
-1. runs the test suite;
-2. builds Release and verifies the embedded documentation is intact in the assembly — a plugin
+1. validates the tag and parses it into a version, before anything else runs;
+2. runs the test suite;
+3. builds Release and verifies the embedded documentation is intact in the assembly — a plugin
    install is a binary-only install, so this is the only proof the knowledge tools still answer;
-3. publishes the self-contained, single-file, **untrimmed** `win-x64` exe;
-4. assembles the pylabview bundle with `tools\pylabview\provision.ps1`, from a pinned CPython plus
+4. publishes the self-contained, single-file, **untrimmed** `win-x64` exe, with the tag stamped
+   into its version resource (`-p:Version=`), and asserts the stamp landed — the csproj default is
+   `0.0.0`, which marks a build that did not come from the workflow;
+5. assembles the pylabview bundle with `tools\pylabview\provision.ps1`, from a pinned CPython plus
    a `pip install pillow` — the runtime is gitignored, so without this step the release carries no
    bundle at all and every `pylv_*` tool answers `notProvisioned` on a plugin install;
-5. assembles the plugin staging tree (the exe at `bin\`, `scripts\` beside it at `bin\scripts\`,
+6. assembles the plugin staging tree (the exe at `bin\`, `scripts\` beside it at `bin\scripts\`,
    `docs\` at `bin\docs\` — some helper scripts read tables out of `docs\` at run time, and
    `scripts\..\docs` has to resolve on an install exactly as it does in the repository — the
    bundle at `bin\pylabview\`, which is where `PyLabview.Locate()` looks, and the `.claude\`
    assets at `bin\claude\`, which is where `Install-ClaudeAssets.ps1` looks: the agents at the zip
    root carry the plugin's tool-name prefix and are useless to an install that registers the
    server directly);
-6. asserts the plugin manifest sits at the tree root;
-7. asserts the staged bundle is locatable **and patched** — the patches in
+7. stamps the version into the artefact — `VERSION.txt` at the archive root (tag, version, commit,
+   build time, run URL) and `plugin.json`'s `version`, substituted from its `0.0.0` placeholder and
+   read back through a JSON parser. `VERSION.txt` is the one that matters for a hand-extracted
+   install: a file **name** dies at extraction, so without it an extracted folder cannot say what
+   it is;
+8. asserts the plugin manifest and `VERSION.txt` sit at the tree root;
+9. asserts the staged bundle is locatable **and patched** — the patches in
    `tools\pylabview\patches\patches.json` are applied when the bundle is assembled, so a stale
    runtime would ship the crash they fix while every log line still read "assembled" — and that
    **both agent flavours** are staged, complete, and naming the tool prefix their own install
    serves;
-8. smoke-tests the staged interpreter (`import PIL`, `from pylabview import LVblock`) and the exe
-   with `--help`;
-9. zips it and attaches `labview-mcp.zip` to a new GitHub Release for the tag.
+10. smoke-tests the staged interpreter (`import PIL`, `from pylabview import LVblock`) and the exe
+    with `--help` and with `--version`, the latter asserting the **output** names the tag, the
+    version and the commit — which also proves `VERSION.txt` is where the exe looks for it;
+11. zips it and attaches four assets: `labview-mcp.zip` (the fixed name the marketplace resolves,
+    never to be renamed), `labview-mcp-vX.Y.Z.zip` (the same bytes, self-identifying, for a human
+    download), `labview-mcp.sha256`, and `labview-mcp.manifest.sha256` — path plus SHA-256 of every
+    file in the archive, which is what lets any install be verified with no second install to
+    compare against.
 
-The asset is about 38 MB larger since step 4 was added.
+The asset is about 38 MB larger since step 5 was added.
 
 Nothing in the marketplace manifest needs editing between releases: it points at
 `releases/latest/download/labview-mcp.zip`, which GitHub redirects to the newest release, and no

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -1,0 +1,193 @@
+# Release versioning — telling one install from another
+
+Everything here was measured on 2026-09-11, settling a report that the plugin install "behaves
+differently" from the release-page download, and specifically that its Python tooling was
+incomplete. It is not. The report was true as an observation and wrong as a diagnosis, and the
+reason nobody could tell was that **nothing in an install carried a version**.
+
+## 1. The two install routes are the same bytes, by construction
+
+`.claude-plugin/marketplace.json` declares the plugin with an `archive` source:
+
+```json
+"source": { "source": "archive",
+            "url": "https://github.com/Zuehlke/labview-mcp/releases/latest/download/labview-mcp.zip" }
+```
+
+That is the asset on the Releases page. There is one build, one packaging path and one artefact, so
+a difference between a store install and a hand-extracted zip can only be **version skew** or a
+**damaged copy** — never a different build. The release workflow has no second branch.
+
+Confirmed file by file over the same tag (v1.3.0), a plugin cache install against a `tar -xf`
+extract of the asset:
+
+| | plugin install | zip extract |
+|---|---|---|
+| files compared | 732 | 732 |
+| differing hashes | **0** | |
+| pylabview bundle, non-`.pyc` | 703 files | 703 files, every SHA-256 equal |
+| `--pylv-status` | python 3.12 x64, pylabview `69768647…` | identical |
+
+Two categories are excluded from that count and both were then checked separately: the 70 `.pyc`
+files (CPython stamps the source mtime and size into the bytecode header, so identical `.py` gives
+different `.pyc` bytes — **all 70 matched past the 16-byte header**), and `bundle.json`, which
+records provisioning time and **matched outright**, both sides reading
+`provisioned 2026-09-11 09:43:14Z`. So 803 of 803 files are the same.
+
+`scripts/Compare-Installs.ps1` is that comparison, and it carries a negative control: a manifest
+with one bogus entry and one altered hash is reported as one missing file and one differing file,
+exit 1.
+
+## 2. What the reported difference actually was
+
+The plugin was serving a copy from **29 August** while the zip extract was from **3 September** —
+and the current release that day was v1.3.0. The cause was one stale field:
+`~/.claude/plugins/known_marketplaces.json` read `"lastUpdated": "2026-08-29T13:00:32Z"`. A
+marketplace catalogue does not refresh itself on demand, so `claude plugin install` had been
+installing a three-release-old archive.
+
+What that older copy was missing looks exactly like "the plugin ships less":
+
+| missing from the 29 August copy | |
+|---|---|
+| `bin/claude/` | the entire directory — agents, `settings.json`, `CLAUDE.md` |
+| `agents/` | 5 of the 8 definitions |
+| `bin/scripts/` | the LUnit, DQMH and class-method helpers |
+| `bin/docs/` | 5 documents |
+
+The pylabview bundle was **not** among the differences. The fix is
+`claude plugin marketplace update zuehlke-labview` followed by `claude plugin update labview-mcp`.
+
+## 3. The identifiers, and which of them already existed
+
+Diagnosing the above cost hashing 800 files across two installs, because all three copies on the
+machine reported the same version. Measured:
+
+| install | `ProductVersion` | really was |
+|---|---|---|
+| plugin, 11 September | `1.0.0+e08bf939…` | v1.3.0 |
+| plugin, 29 August | `1.0.0+…` | three releases older |
+| extract at `C:\Projects\labview-mcp` | `1.0.0+4e71ce40…` | **v1.0.7** |
+
+`1.0.0` is the .NET SDK default: the csproj set no `Version` at all, so every release ever
+published carried it, and a local debug build carried the identical number.
+
+**The commit was there the whole time.** The SDK appends `SourceRevisionId` to
+`InformationalVersion`, so the shipped exe already identified its source commit exactly — and
+`e08bf939…` resolves to the v1.3.0 tag, `4e71ce40…` to v1.0.7. The plumbing existed; only the
+semantic half and the surfacing were missing. On any install, including one built before this
+document:
+
+```powershell
+(Get-Item <install>\bin\LabVIEWMCP.exe).VersionInfo.ProductVersion
+```
+
+then `git describe --tags --exact-match <sha>`.
+
+## 4. The tag is the version, so the tag is validated
+
+`scripts/Assert-ReleaseTag.ps1` is the **first** step of the release workflow, before the test
+run, so a mistyped tag costs seconds and publishes nothing. The rule:
+
+> `vX.Y.Z` — a lower-case `v` followed by exactly three decimal numbers separated by dots, and
+> nothing else.
+
+It exists because the tags did not agree on a format. As of 2026-09-11: `v1.3.0`, `v1.1.1`,
+`v1.0.7` lower-case; `V1.2.8`, `V1.2.5`, `V1.2.2`, `V1.2.0`, `V1.1.5` **upper-case**; and `v10.4`
+with **two components**. Each of those is a distinct hazard, which is why the refusal names the
+specific mistake rather than printing a regex:
+
+| refused | why it matters |
+|---|---|
+| upper-case `V` | git refs are case-sensitive, so `V1.2.3` and `v1.2.3` can both exist on different commits — and a case-insensitive listing gives no hint that both are there |
+| no leading `v` | the workflow triggers on `v*`, so the tag publishes nothing at all and leaves no failed run to notice |
+| two components (`v10.4`) | a version needs three — and a two-part tag sorts **above** every three-part one in `git tag --sort=-v:refname`, so it permanently masks the real newest release in every listing |
+| four components | MSBuild fills the fourth `FileVersion` field itself; supplying it makes the tag and the assembly disagree |
+| `-rc1` / `+meta` suffix | MSBuild accepts a suffix in `InformationalVersion` but not in `FileVersion`; there is no pre-release channel here |
+| non-numeric component | `FileVersion` fields take digits only, so it cannot be built at all |
+| **leading zero** (`v1.02.3`) | MSBuild reads `02` as `2`, so this tag and its zero-free twin stamp an **identical** version into every artefact while remaining two different git refs — two releases no installed copy could tell apart |
+
+Every refusal prints the tag, the rule, why it matters, the probable intended tag, and the
+delete-and-retag commands. Check a tag before pushing it and it never fires:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\Assert-ReleaseTag.ps1 -Tag v1.4.0
+```
+
+`ReleaseTagTests` drives the real script rather than re-stating its regex — a rule re-implemented
+in a test can agree with the test and disagree with the release. It asserts the message names the
+actual mistake, and that each suggested tag is one the script would then accept.
+
+## 5. Where the version is stamped
+
+| place | how | read it with |
+|---|---|---|
+| the exe's Win32 version resource | `dotnet publish -p:Version=X.Y.Z` | Explorer → Properties → Details, or `(Get-Item …).VersionInfo` |
+| the managed assembly | same property; the SDK appends `+<sha>` | `LabVIEWMCP.exe --version` |
+| `lvai_status` | `serverVersion`, `serverCommit` | needs LabVIEW running |
+| `pylv_status` | `serverVersion`, `serverCommit` | **needs no LabVIEW** — including on its `notProvisioned` failure path |
+| `plugin.json` `version` | substituted at staging from the `0.0.0` placeholder | `claude plugin list`, `claude plugin details` |
+| `VERSION.txt` at the archive root | written at staging | `Get-Content <install>\VERSION.txt` |
+
+**`0.0.0` means "not a release build".** It is the csproj default and deliberately not `1.0.0`: a
+dev build may report itself as one, but it must not pass for a release. `--version` prints
+`0.0.0-dev` for it.
+
+**`VERSION.txt` is the one that matters for an extracted folder**, because a file name dies at
+extraction — which is precisely why `C:\Projects\labview-mcp` could not say what it was. It
+carries the tag, which the assembly cannot: the assembly knows `1.3.0`, not that it came from
+`v1.3.0`.
+
+The workflow asserts the stamp rather than assuming it: `-p:Version=` is silently ignored if the
+property is overridden later in the build, and an exe reporting `0.0.0` from a tagged release
+looks exactly like a dev build to every later check. It also runs `--version` from the staged exe
+and requires the tag, the version and the commit to appear in the output — which additionally
+proves `VERSION.txt` sits where the exe looks for it (`<exe dir>\..\VERSION.txt`).
+
+## 6. The release assets
+
+| asset | why |
+|---|---|
+| `labview-mcp.zip` | **load-bearing and must never be renamed** — the marketplace resolves `/releases/latest/download/labview-mcp.zip`, which is why the manifest needs no editing after a release |
+| `labview-mcp-vX.Y.Z.zip` | the same bytes under a self-identifying name, for the human downloading from the Releases page |
+| `labview-mcp.sha256` | the archive's digest, in `sha256sum -c` format |
+| `labview-mcp.manifest.sha256` | path + SHA-256 of **every** file in the archive |
+
+The last one is what retires this whole investigation: it answers "is my install intact and
+complete?" with **no second install to compare against**, and it catches a missing file as well as
+an altered one.
+
+```powershell
+.\scripts\Compare-Installs.ps1 -PluginRoot <install root> -ManifestPath .\labview-mcp.manifest.sha256
+```
+
+## 7. One asymmetry that is real, and favours the plugin
+
+The two routes differ in **how the archive is extracted**, not in what it contains. Explorer's
+"Extract All" propagates the Mark-of-the-Web `Zone.Identifier` alternate data stream onto every
+extracted file, which can make the bundled `python.exe` and its DLLs prompt or fail; the plugin
+installer fetches and unpacks programmatically and carries no MOTW. So use `tar -xf` (it ships in
+`System32` on Windows 10+) for a manual install, and check with
+`Get-Item -Stream Zone.Identifier` if the bundle misbehaves.
+
+The other route-level differences are not content either, and none of them is "less Python":
+
+- **Tool-name prefix.** A plugin serves `mcp__plugin_labview-mcp_labview__lvai_*`; a direct
+  registration serves `mcp__labview__lvai_*`. The archive ships both agent flavours for that
+  reason — `agents/` at the root for the plugin loader, `bin/claude/agents/` for
+  `Install-ClaudeAssets.ps1`.
+- **Agents and hooks load automatically only on the plugin route.** A manual install that skips
+  `scripts\Install-ClaudeAssets.ps1` has no agents and no read-only allow-list, which reads as
+  reduced functionality.
+- **The cache is shared.** `CacheDirectory.Root` is `%USERPROFILE%\.labviewmcp\cache` precisely so
+  that it does not depend on who launched the server; under `%LOCALAPPDATA%` a desktop-app-launched
+  server landed in the packaged app's private store and a terminal-launched one did not, giving one
+  machine two caches.
+
+## 8. The process lesson
+
+The version was *almost* there. The commit SHA had been in every published exe from the start, and
+answering "which build is this?" still took an afternoon — because nothing surfaced it, and the one
+number that was surfaced (`1.0.0`) was the same for every build ever made. **A value that exists
+but is not reported is not an answer**, which is the same shape as this repository's
+embedded-but-unshipped documents: present in the artefact, reachable by nobody.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "labview-mcp",
   "displayName": "LabVIEW MCP",
+  "version": "0.0.0",
   "description": "Read, write and run LabVIEW 2026 code from an AI assistant - VIs as text via AIXML, classes and interfaces through NI's own project providers, palette and shipping-example search, Caraya unit tests, DQMH modules and events driven through Delacor's own scripting, and eight bundled LabVIEW agents. Windows x64 only.",
   "author": {
     "name": "Zühlke Engineering AG"

--- a/scripts/Assert-ReleaseTag.ps1
+++ b/scripts/Assert-ReleaseTag.ps1
@@ -1,0 +1,207 @@
+<#
+.SYNOPSIS
+    Refuse a release tag that is not exactly vX.Y.Z, and say precisely what is wrong with it.
+
+.DESCRIPTION
+    The release workflow reads the tag and stamps it into three places that all need a numeric
+    three-part version: the assembly's FileVersion/ProductVersion, plugin.json's `version`, and
+    VERSION.txt inside the archive. A tag MSBuild cannot parse either fails the build halfway
+    through or - worse - is silently coerced, which is how two different tags come to stamp the
+    same version.
+
+    WHY THIS EXISTS. The tags in this repository do not agree on a format. Measured 2026-09-11:
+    v1.3.0, v1.1.1 and v1.0.7 are lower-case; V1.2.8, V1.2.5, V1.2.2, V1.2.0 and V1.1.5 are
+    upper-case; and v10.4 has only two components. That last one also sorts ABOVE every
+    three-part tag in `git tag --sort=-v:refname`, so for ten days the newest-looking tag in the
+    list was neither the newest release nor a valid version - which is how a release process
+    loses track of what it has shipped.
+
+    THE RULE: `v`, lower-case, then three decimal components separated by dots, nothing else.
+    Leading zeros are refused as well, because MSBuild reads 02 as 2, so `v1.02.3` would be
+    indistinguishable from `v1.2.3` in every artefact this stamps while remaining a different
+    git ref.
+
+.PARAMETER Tag
+    The tag to check. A `refs/tags/` prefix is accepted and stripped, so the workflow may pass
+    either $env:GITHUB_REF or $env:GITHUB_REF_NAME without caring which it has.
+
+.OUTPUTS
+    On success: prints the accepted tag and its version and, under GitHub Actions, writes `tag`
+    and `version` to $GITHUB_OUTPUT for later steps. Exit code 0.
+    On failure: prints the diagnosis and the remedy. Exit code 1.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File scripts\Assert-ReleaseTag.ps1 -Tag v1.3.0
+
+.EXAMPLE
+    # What a maintainer should run BEFORE pushing a tag.
+    powershell -ExecutionPolicy Bypass -File scripts\Assert-ReleaseTag.ps1 -Tag v1.4.0
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][AllowEmptyString()][string]$Tag
+)
+
+$ErrorActionPreference = 'Stop'
+
+# refs/tags/v1.2.3 -> v1.2.3. Accepted rather than refused: which of the two GitHub hands you
+# depends on the variable the workflow happened to use, and that is not a tagging mistake.
+$raw = $Tag
+$tag = $Tag
+if ($tag -like 'refs/tags/*') { $tag = $tag.Substring('refs/tags/'.Length) }
+
+# THE rule, in one place, quoted by every message below so the text cannot drift from the regex.
+$Rule = 'vX.Y.Z - a lower-case "v" followed by exactly three decimal numbers separated by dots, and nothing else. Examples: v1.0.0, v1.3.0, v12.7.31'
+$Pattern = '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
+function Deny {
+    param([string]$Problem, [string]$Why, [string]$Suggested)
+
+    # Everything a reader needs without opening a file: what arrived, what is wrong with it, why
+    # the rule exists, and the commands that fix an already-pushed tag. A release that fails with
+    # "invalid tag" and nothing else is how a check like this gets worked around instead of obeyed.
+    $lines = @(
+        '',
+        '=====================================================================',
+        ' RELEASE REFUSED - the tag is not a valid version',
+        '=====================================================================',
+        '',
+        "  tag pushed    :  $raw",
+        "  problem       :  $Problem",
+        "  why it matters:  $Why",
+        '',
+        "  required form :  $Rule"
+    )
+    if ($Suggested) { $lines += @('', "  you probably meant:  $Suggested") }
+    $lines += @(
+        '',
+        '  Nothing has been built or published. Delete the bad tag and push a correct one:',
+        '',
+        "      git tag -d $tag",
+        "      git push origin :refs/tags/$tag"
+    )
+    $lines += if ($Suggested) {
+        @("      git tag $Suggested <commit>", "      git push origin $Suggested")
+    } else {
+        @('      git tag vX.Y.Z <commit>', '      git push origin vX.Y.Z')
+    }
+    $lines += @(
+        '',
+        '  Check a tag before pushing it and this never fires:',
+        '',
+        '      powershell -ExecutionPolicy Bypass -File scripts\Assert-ReleaseTag.ps1 -Tag vX.Y.Z',
+        '',
+        '====================================================================='
+    )
+    $lines | ForEach-Object { Write-Host $_ -ForegroundColor Red }
+    exit 1
+}
+
+# ---------------------------------------------------------------------------------------------
+# The specific diagnoses, ordered so the most informative one wins. A single "does not match the
+# pattern" would be correct and useless: the value of this check is telling the maintainer WHICH
+# of the plausible mistakes they made.
+# ---------------------------------------------------------------------------------------------
+
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    Deny 'the tag is empty' `
+         'there is no version to stamp into the assembly, plugin.json or VERSION.txt' `
+         ''
+}
+
+if ($tag -ne $tag.Trim()) {
+    Deny "the tag has leading or trailing whitespace ('$tag')" `
+         'git accepts it and every string comparison downstream does not' `
+         $tag.Trim()
+}
+
+if ($tag -cmatch '^V') {
+    # First, because it is the mistake this repository actually keeps making - five of the nine
+    # existing tags - and because a case-insensitive listing shows no sign of it.
+    $fixed = 'v' + $tag.Substring(1)
+    Deny "the tag starts with an upper-case 'V'" `
+         ('git refs are case-sensitive, so V1.2.3 and v1.2.3 are two different tags that can both ' +
+          'exist, on different commits, pointing at different releases - and a listing sorted ' +
+          'case-insensitively gives no hint that both are there') `
+         $(if ($fixed -cmatch $Pattern) { $fixed } else { '' })
+}
+
+if ($tag -cnotmatch '^v') {
+    $fixed = 'v' + $tag
+    Deny "the tag does not start with a lower-case 'v'" `
+         ('the release workflow triggers on tags matching v*, so a tag without the prefix builds ' +
+          'and publishes nothing at all, with no failed run to notice') `
+         $(if ($fixed -cmatch $Pattern) { $fixed } else { '' })
+}
+
+$body = $tag.Substring(1)
+
+if ($body -match '[-+]') {
+    $split = $body -split '[-+]', 2
+    Deny "the tag carries a pre-release or build suffix ('$($split[1])')" `
+         ('MSBuild accepts a suffix in InformationalVersion but not in FileVersion, so the stamped ' +
+          'assembly and the published tag would no longer say the same thing; this project has no ' +
+          'pre-release channel') `
+         $(if ("v$($split[0])" -cmatch $Pattern) { "v$($split[0])" } else { '' })
+}
+
+$parts = $body.Split('.')
+
+if ($parts.Count -ne 3) {
+    $suggested = switch ($parts.Count) {
+        1 { "v$body.0.0" }
+        2 { "v$body.0" }
+        default { 'v' + ($parts[0..2] -join '.') }
+    }
+    $why = if ($parts.Count -lt 3) {
+        'a version needs three components. A two-part tag such as v10.4 also sorts ABOVE every ' +
+        'three-part tag in `git tag --sort=-v:refname`, so it permanently masks the real newest ' +
+        'release in every listing'
+    } else {
+        'FileVersion has a fourth field that MSBuild fills in itself, so supplying it means the ' +
+        'tag and the assembly disagree about the version'
+    }
+    Deny "the tag has $($parts.Count) component(s) rather than 3 ('$body')" $why `
+         $(if ($suggested -cmatch $Pattern) { $suggested } else { '' })
+}
+
+$names = @('major', 'minor', 'patch')
+
+$nonNumeric = @(0..2 | Where-Object { $parts[$_] -notmatch '^[0-9]+$' })
+if ($nonNumeric.Count -gt 0) {
+    $named = $nonNumeric | ForEach-Object { "$($names[$_]) = '$($parts[$_])'" }
+    Deny "a version component is not a decimal number ($($named -join ', '))" `
+         ('every component is stamped into a numeric FileVersion field, which takes digits only, ' +
+          'so a non-numeric component cannot be built at all') `
+         ''
+}
+
+$leadingZero = @(0..2 | Where-Object { $parts[$_].Length -gt 1 -and $parts[$_].StartsWith('0') })
+if ($leadingZero.Count -gt 0) {
+    $trimmed = 'v' + (($parts | ForEach-Object { [string][int]$_ }) -join '.')
+    Deny "a version component has a leading zero ('$body')" `
+         ('MSBuild reads 02 as 2, so this tag and its zero-free twin stamp an IDENTICAL version ' +
+          'into the assembly, plugin.json and VERSION.txt while remaining two different git refs - ' +
+          'two releases no installed copy could tell apart') `
+         $trimmed
+}
+
+if ($tag -cnotmatch $Pattern) {
+    # Unreachable given the diagnoses above. Kept so that a later edit narrowing $Pattern fails
+    # loudly here instead of letting an unchecked tag through.
+    Deny "the tag is not a valid version ('$tag')" `
+         'the version is stamped into the assembly, plugin.json and VERSION.txt' ''
+}
+
+$version = $body
+
+Write-Host "release tag OK: $tag  ->  version $version" -ForegroundColor Green
+
+# Hand the parsed version to the following workflow steps. Guarded, so a local run - the way a
+# maintainer is meant to check a tag before pushing it - works with no GitHub environment.
+if ($env:GITHUB_OUTPUT) {
+    "tag=$tag"         | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+exit 0

--- a/scripts/Compare-Installs.ps1
+++ b/scripts/Compare-Installs.ps1
@@ -1,0 +1,182 @@
+<#
+.SYNOPSIS
+    Prove that two installs of this server hold the same bytes - or that one install matches the
+    release's published file manifest.
+
+.DESCRIPTION
+    THE PLUGIN AND THE RELEASES-PAGE DOWNLOAD ARE THE SAME ARTEFACT BY CONSTRUCTION.
+    .claude-plugin/marketplace.json declares the plugin as an `archive` source pointing at
+    releases/latest/download/labview-mcp.zip, so a store install is that asset unpacked. There is
+    one build and one packaging path, so a difference between two installs can only be version
+    skew or a damaged copy - never a different build.
+
+    WHY THIS EXISTS. Measured 2026-09-11, after a report that the plugin install "behaves
+    differently" from the zip, specifically that its Python tooling was incomplete. It is not: over
+    the same tag the two routes came out identical - 732 files, every SHA-256 equal, the pylabview
+    bundle byte-for-byte the same 703 files reporting the same interpreter and the same upstream
+    commit. The reported difference was entirely age: the marketplace catalogue had not been
+    refreshed since 2026-08-29, so the plugin was serving a copy three releases old, missing five
+    of the eight agents and all of bin\claude\. Nothing could say so, because nothing in either
+    install carried a version.
+
+    COMPARE THE SAME TAG. A current plugin against an older extract reproduces exactly the
+    confusion this script exists to settle. `LabVIEWMCP.exe --version` and VERSION.txt at each
+    install's root name the release; before v1.3.1 neither existed, and the only identifier is the
+    commit SHA in the exe:
+        (Get-Item <install>\bin\LabVIEWMCP.exe).VersionInfo.ProductVersion
+    which resolves with `git describe --tags --exact-match <sha>`.
+
+.PARAMETER PluginRoot
+    An install root - the folder holding .claude-plugin\, bin\, agents\. For a plugin install this
+    is under ~\.claude\plugins\cache\<marketplace>\<plugin>\<hash>\; find it with
+
+        Get-ChildItem "$HOME\.claude\plugins\cache" -Recurse -Depth 3 -Directory -Filter bin |
+          ForEach-Object { Split-Path $_.FullName -Parent }
+
+.PARAMETER ZipRoot
+    The other install root, typically a hand-extracted labview-mcp.zip. Extract it with
+    `tar -xf` rather than Explorer's "Extract All": Explorer propagates the Mark-of-the-Web
+    Zone.Identifier stream onto every extracted file, which can make the bundled python.exe and
+    its DLLs prompt or fail outright.
+
+.PARAMETER ManifestPath
+    Instead of a second install: labview-mcp.manifest.sha256 from the release, which lists the
+    SHA-256 and relative path of every file in the archive. This is the cheaper check - it needs
+    no second copy, and it detects a file that is missing from the install as well as one that has
+    been altered.
+
+.EXAMPLE
+    # Two installs against each other.
+    .\Compare-Installs.ps1 -PluginRoot "$HOME\.claude\plugins\cache\zuehlke-labview\labview-mcp\fdf2387026da" -ZipRoot "$HOME\lvmcp-compare\zip"
+
+.EXAMPLE
+    # One install against the release's own manifest.
+    .\Compare-Installs.ps1 -PluginRoot "$HOME\.claude\plugins\cache\zuehlke-labview\labview-mcp\fdf2387026da" -ManifestPath .\labview-mcp.manifest.sha256
+
+.OUTPUTS
+    Exit code 0 when everything matches, 1 otherwise.
+#>
+[CmdletBinding(DefaultParameterSetName = 'TwoInstalls')]
+param(
+    [Parameter(Mandatory, Position = 0)][string]$PluginRoot,
+    [Parameter(Mandatory, ParameterSetName = 'TwoInstalls', Position = 1)][string]$ZipRoot,
+    [Parameter(Mandatory, ParameterSetName = 'Manifest')][string]$ManifestPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Excluded because they differ BY DESIGN rather than by content, and including them would report a
+# difference on every single comparison - which is how a check stops being read:
+#   *.pyc       CPython stamps the source file's mtime and size into the bytecode header, so two
+#               copies of an identical .py yield different .pyc bytes. Measured over 70 of them:
+#               past the 16-byte header, every one matched.
+#   bundle.json records when the pylabview bundle was provisioned.
+#   VERSION.txt names the release; it is the thing you compare BEFORE running this, not with it.
+# .in_use and .orphaned_at are Claude Code's own bookkeeping in a plugin cache folder.
+$Skip = @('*.pyc', 'bundle.json', 'VERSION.txt', '.in_use', '.orphaned_at')
+
+function Get-Manifest {
+    param([string]$Root)
+
+    if (-not (Test-Path -LiteralPath $Root)) { throw "no such directory: $Root" }
+    $full = (Resolve-Path -LiteralPath $Root).Path
+    $table = @{}
+    # -Exclude with -Recurse is unreliable in Windows PowerShell 5.1, so the count is verified
+    # against an unfiltered enumeration below rather than trusted. A silently skipped subtree
+    # would make this script report "identical" over a subset, which is worse than reporting
+    # nothing at all.
+    $all = @(Get-ChildItem -LiteralPath $full -Recurse -File -Force)
+    foreach ($file in $all) {
+        $name = $file.Name
+        if ($Skip | Where-Object { $name -like $_ }) { continue }
+        $rel = $file.FullName.Substring($full.Length).TrimStart('\').Replace('\', '/')
+        $table[$rel] = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+    $skipped = $all.Count - $table.Count
+    Write-Host ("  {0,5} files, {1} excluded by design  {2}" -f $table.Count, $skipped, $full)
+    return $table
+}
+
+function Show-Group {
+    param([string]$Title, [string[]]$Items)
+
+    Write-Host ''
+    if ($Items.Count -eq 0) {
+        Write-Host "  none  -  $Title" -ForegroundColor Green
+    } else {
+        Write-Host "  $($Items.Count)  -  $Title" -ForegroundColor Yellow
+        $Items | ForEach-Object { Write-Host "        $_" }
+    }
+}
+
+function Show-Version {
+    param([string]$Label, [string]$Root)
+
+    # Report what each side SAYS it is before reporting whether they match: a difference between
+    # two different releases is not a finding, and saying so up front is what stops this from
+    # being read as a packaging fault.
+    $versionFile = Join-Path $Root 'VERSION.txt'
+    $exe = Join-Path $Root 'bin\LabVIEWMCP.exe'
+    $said = if (Test-Path -LiteralPath $versionFile) {
+        (Get-Content -LiteralPath $versionFile | Where-Object { $_ -like 'tag:*' }) -replace 'tag:\s*', ''
+    } elseif (Test-Path -LiteralPath $exe) {
+        '(no VERSION.txt; exe says ' + (Get-Item -LiteralPath $exe).VersionInfo.ProductVersion + ')'
+    } else {
+        '(unknown - no VERSION.txt and no bin\LabVIEWMCP.exe)'
+    }
+    Write-Host ("  {0,-8} {1}" -f $Label, $said)
+}
+
+Write-Host ''
+Write-Host 'release each side reports:'
+Show-Version 'A' $PluginRoot
+if ($PSCmdlet.ParameterSetName -eq 'TwoInstalls') { Show-Version 'B' $ZipRoot }
+
+Write-Host ''
+Write-Host 'hashing:'
+$have = Get-Manifest $PluginRoot
+
+if ($PSCmdlet.ParameterSetName -eq 'Manifest') {
+    if (-not (Test-Path -LiteralPath $ManifestPath)) { throw "no such manifest: $ManifestPath" }
+    $want = @{}
+    foreach ($line in Get-Content -LiteralPath $ManifestPath) {
+        if ($line -match '^([0-9a-fA-F]{64})\s\s?(.+)$') {
+            $rel = $Matches[2].Trim()
+            $name = Split-Path $rel -Leaf
+            if ($Skip | Where-Object { $name -like $_ }) { continue }
+            $want[$rel] = $Matches[1].ToLowerInvariant()
+        }
+    }
+    if ($want.Count -eq 0) { throw "$ManifestPath holds no '<sha256>  <path>' lines" }
+    Write-Host ("  {0,5} entries in the manifest (after the same exclusions)" -f $want.Count)
+    $leftLabel = 'the install'
+    $rightLabel = 'the release manifest'
+} else {
+    $want = Get-Manifest $ZipRoot
+    $leftLabel = 'install A'
+    $rightLabel = 'install B'
+}
+
+$onlyLeft  = @($have.Keys | Where-Object { -not $want.ContainsKey($_) } | Sort-Object)
+$onlyRight = @($want.Keys | Where-Object { -not $have.ContainsKey($_) } | Sort-Object)
+$differing = @($have.Keys | Where-Object { $want.ContainsKey($_) -and $want[$_] -ne $have[$_] } | Sort-Object)
+
+Show-Group "present only in $leftLabel"  $onlyLeft
+Show-Group "present only in $rightLabel" $onlyRight
+Show-Group 'same path, DIFFERENT bytes'  $differing
+
+Write-Host ''
+if ($onlyLeft.Count -eq 0 -and $onlyRight.Count -eq 0 -and $differing.Count -eq 0) {
+    Write-Host 'IDENTICAL - nothing differs outside the by-design exclusions.' -ForegroundColor Green
+    exit 0
+}
+
+Write-Host 'DIFFERENT.' -ForegroundColor Red
+Write-Host ''
+Write-Host '  Check the release each side reports (above) BEFORE suspecting the packaging: the two' -ForegroundColor Red
+Write-Host '  install routes take the same archive, so different bytes almost always means one side' -ForegroundColor Red
+Write-Host '  is a different release. Refresh a stale plugin with:' -ForegroundColor Red
+Write-Host ''
+Write-Host '      claude plugin marketplace update zuehlke-labview' -ForegroundColor Red
+Write-Host '      claude plugin update labview-mcp' -ForegroundColor Red
+exit 1

--- a/src/LabVIEWMCP/Cli/CommandLine.cs
+++ b/src/LabVIEWMCP/Cli/CommandLine.cs
@@ -17,6 +17,7 @@ internal static class CommandLine
         ["--help"] = false,
         ["-h"] = false,
         ["-?"] = false,
+        ["--version"] = false,
         ["--selftest"] = false,
         ["--ensure-labview"] = false,
         ["--dump-schema"] = true, // the file is optional; the value test below handles that
@@ -123,6 +124,10 @@ internal static class CommandLine
           --no-annotate     --pylv-extract leaves primResID/parmIndex numbers unnamed
           --fields <spec>   --create-class private data, as <type>.<name> comma separated
           --parent <path>   --create-class parent .lvclass to derive from
+          --version         print this build's version, commit and exe path, and the release
+                            archive's VERSION.txt when there is one beside it. Needs no
+                            LabVIEW. This is how you tell a plugin install from a hand-
+                            extracted zip - or an older copy of either from a current one
           --help            print this text
 
         LABVIEW_GRPC_PORT works instead of --port, LABVIEWMCP_LVVERSION instead of

--- a/src/LabVIEWMCP/Infra/ServerVersion.cs
+++ b/src/LabVIEWMCP/Infra/ServerVersion.cs
@@ -1,0 +1,119 @@
+using System.Reflection;
+
+namespace LabVIEWMcp.Infra;
+
+/// <summary>
+/// Which build of this server is running - the one question a stdio MCP server could not answer
+/// about itself until 2026-09-11.
+///
+/// WHY THIS EXISTS. A colleague reported that the plugin install "behaves differently" from the
+/// release zip. Measured that day, the two routes are the same bytes by construction: the
+/// marketplace declares the plugin as an `archive` source pointing at
+/// releases/latest/download/labview-mcp.zip, so the store install IS that asset unpacked -
+/// confirmed file by file, 732 files, every SHA-256 equal. The reported difference was entirely
+/// version skew: the marketplace catalogue had not been refreshed since 2026-08-29, so the plugin
+/// was serving a copy three releases old.
+///
+/// Settling that took hashing 800 files across two installs, because nothing could say what it
+/// was. All three copies on the machine reported FileVersion 1.0.0 - the SDK default, since the
+/// csproj set no Version - and neither plugin.json nor the archive carried a version either.
+///
+/// What WAS already there is the commit: the .NET SDK appends SourceRevisionId to
+/// InformationalVersion, so the shipped exe read `1.0.0+e08bf939...`, and that SHA resolved
+/// exactly to the v1.3.0 tag (and the other install's to v1.0.7). So this type is mostly about
+/// reading a value that was always present and has never been surfaced.
+///
+/// Reported by `--version`, by `lvai_status` and by `pylv_status`. That last one matters: it is
+/// the only one of the three that answers with no LabVIEW running, which is precisely the state
+/// in which someone asks whether their install is intact.
+/// </summary>
+internal static class ServerVersion
+{
+    /// <summary>The version stamped at build time, and the commit it was built from.</summary>
+    /// <param name="Version">
+    /// Three-part version from the release tag, or <c>0.0.0</c> for any build that did not come
+    /// from the release workflow.
+    /// </param>
+    /// <param name="Commit">
+    /// Full commit SHA, when the SDK recorded one. Null for a build with no git information -
+    /// which is normal for a source archive, and never the case for a published release.
+    /// </param>
+    /// <param name="IsRelease">
+    /// False when <see cref="Version"/> is <c>0.0.0</c>. A dev build is allowed to report itself
+    /// as one; what it must not do is pass for a release.
+    /// </param>
+    internal sealed record Info(string Version, string? Commit, bool IsRelease)
+    {
+        /// <summary>
+        /// One line for a human: "1.3.0 (e08bf939)" or "0.0.0-dev (local build)". Keep the shape
+        /// stable - it goes into --version output and into two tool answers.
+        /// </summary>
+        public string Display =>
+            (IsRelease ? Version : Version + "-dev")
+            + (Commit is { Length: >= 8 } c ? $" ({c[..8]})" : " (no commit recorded)");
+    }
+
+    private static Info? _cached;
+
+    /// <summary>
+    /// This assembly's version, read once. Cached because it cannot change within a process and
+    /// both status tools call it on every invocation.
+    /// </summary>
+    public static Info Current => _cached ??= Read(
+        typeof(ServerVersion).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+
+    /// <summary>
+    /// Split an InformationalVersion into its two halves. Exposed for the tests: the interesting
+    /// input shapes are all produced by the build, so there is no other way to exercise them.
+    ///
+    /// The SDK's format is `<version>+<sha>`, and every part of that is optional in practice -
+    /// a build with no git information carries no `+` at all, and a hand-set
+    /// InformationalVersion may carry a `-suffix` the release workflow never produces. Anything
+    /// unparseable degrades to 0.0.0 rather than throwing: a version reader that can fail is a
+    /// status tool that can fail, which is the opposite of the point.
+    /// </summary>
+    internal static Info Read(string? informational)
+    {
+        if (string.IsNullOrWhiteSpace(informational)) return new Info("0.0.0", null, false);
+
+        var plus = informational.IndexOf('+');
+        var version = (plus < 0 ? informational : informational[..plus]).Trim();
+        var commit = plus < 0 || plus == informational.Length - 1
+            ? null
+            : informational[(plus + 1)..].Trim();
+
+        if (version.Length == 0) version = "0.0.0";
+        return new Info(version, string.IsNullOrEmpty(commit) ? null : commit,
+                        version != "0.0.0");
+    }
+
+    /// <summary>
+    /// What `--version` prints. The exe path is part of it on purpose: the whole reason this
+    /// exists is telling two installs apart, and on a machine with both a plugin copy and a
+    /// hand-extracted one the path is what names which of them answered.
+    /// </summary>
+    public static string CliText()
+    {
+        var info = Current;
+        var lines = new List<string>
+        {
+            $"LabVIEW MCP {info.Display}",
+            $"  version        {info.Version}" + (info.IsRelease ? "" : "   (not a release build)"),
+            $"  commit         {info.Commit ?? "(none recorded)"}",
+            $"  exe            {Environment.ProcessPath ?? AppContext.BaseDirectory}",
+        };
+
+        // VERSION.txt travels in the release archive and names the tag, which the assembly does
+        // not: 1.3.0 came from `v1.3.0`, and knowing that saves guessing at the prefix.
+        var versionFile = Path.Combine(AppContext.BaseDirectory, "..", "VERSION.txt");
+        if (File.Exists(versionFile))
+        {
+            lines.Add($"  archive        {Path.GetFullPath(versionFile)}");
+            foreach (var line in File.ReadAllLines(versionFile))
+                if (line.Trim().Length > 0) lines.Add("    " + line.Trim());
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/src/LabVIEWMCP/LabVIEWMCP.csproj
+++ b/src/LabVIEWMCP/LabVIEWMCP.csproj
@@ -10,6 +10,24 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <!-- stdio MCP server: a stray Console.Write would corrupt the protocol stream -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!-- 0.0.0 means "not a release build", and it is deliberately not 1.0.0.
+         The release workflow overrides it with the tag (-p:Version=X.Y.Z, from
+         scripts\Assert-ReleaseTag.ps1), so a stamped exe names the release it came from and an
+         unstamped one says so instead of impersonating one.
+
+         WHY: until 2026-09-11 nothing set Version at all, so every release ever published carried
+         the SDK default 1.0.0 - and a local debug build carried the identical number. Measured
+         over the three installs on one machine that day, all three read `1.0.0`, which is why
+         "which version is this?" could only be answered by hashing 800 files. The commit SHA was
+         in there the whole time (the SDK appends SourceRevisionId to InformationalVersion), so the
+         plumbing existed and only the semantic half was missing. docs\release-versioning.md. -->
+    <Version>0.0.0</Version>
+    <Product>LabVIEW MCP</Product>
+    <Company>Zühlke Engineering AG</Company>
+    <Authors>Zühlke Engineering AG</Authors>
+    <Description>Read, write and run LabVIEW code from an AI assistant over MCP.</Description>
+    <Copyright>Copyright (c) Zühlke Engineering AG</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LabVIEWMCP/Program.cs
+++ b/src/LabVIEWMCP/Program.cs
@@ -20,6 +20,14 @@ if (CommandLine.HasFlag(args, "--help") ||
     return 0;
 }
 
+// Before every other mode, and needing nothing to be running: "which build is this?" is asked
+// precisely when an install is suspected of being broken or stale. See ServerVersion.
+if (CommandLine.HasFlag(args, "--version"))
+{
+    Console.WriteLine(ServerVersion.CliText());
+    return 0;
+}
+
 // Reject a mistyped flag instead of falling through to the stdio server below. That server
 // waits on stdin forever, so "-selftest" with one hyphen looked exactly like a hang and was
 // reported as one (issue #7). Usage goes to stderr: stdout belongs to the MCP protocol.

--- a/src/LabVIEWMCP/Tools/PyLabviewTools.cs
+++ b/src/LabVIEWMCP/Tools/PyLabviewTools.cs
@@ -52,6 +52,11 @@ internal sealed class PyLabviewTools(LvaiConnection connection)
             if (bundle is null)
                 return Task.FromResult(Json.Error("notProvisioned", NotProvisioned, new
                 {
+                    // On the failure path especially: "the bundle is missing" is usually "this
+                    // install is older than v0.9.2", and the version is what settles that without
+                    // a second install to compare against.
+                    serverVersion = ServerVersion.Current.Display,
+                    serverCommit = ServerVersion.Current.Commit,
                     searched = new[]
                     {
                         PyLabview.DirectoryVariable + " (environment)",
@@ -63,6 +68,11 @@ internal sealed class PyLabviewTools(LvaiConnection connection)
             return Task.FromResult(new JsonObject
             {
                 ["ok"] = true,
+                // Which build of the SERVER is answering, not of the bundle. Reported here as
+                // well as in lvai_status because this tool needs no running LabVIEW, and a stale
+                // or half-extracted install is suspected exactly when LabVIEW is not up.
+                ["serverVersion"] = ServerVersion.Current.Display,
+                ["serverCommit"] = ServerVersion.Current.Commit,
                 ["directory"] = bundle.Directory,
                 ["pythonVersion"] = bundle.PythonVersion,
                 ["pythonArch"] = bundle.PythonArch,

--- a/src/LabVIEWMCP/Tools/StatusTools.cs
+++ b/src/LabVIEWMCP/Tools/StatusTools.cs
@@ -68,6 +68,10 @@ internal sealed class StatusTools(LvaiConnection connection)
                 ["port"] = connection.Port,
                 ["discoveredVia"] = connection.DiscoveredVia,
                 ["applicationLanguage"] = config.Language,
+                // Which build of THIS server is answering. A `-dev` suffix means the exe did not
+                // come from the release workflow; `serverCommit` pins it exactly either way.
+                ["serverVersion"] = ServerVersion.Current.Display,
+                ["serverCommit"] = ServerVersion.Current.Commit,
                 ["scriptsDirectory"] = ScriptsDirectory(),
                 ["claudeAssetsDirectory"] = ClaudeAssetsDirectory(),
                 // The add-on build the export cache is keyed to. Reported because a dropped cache

--- a/tests/LabVIEWMCP.Tests/Cli/ReleaseTagTests.cs
+++ b/tests/LabVIEWMCP.Tests/Cli/ReleaseTagTests.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using LabVIEWMcp.Tests.Support;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Cli;
+
+/// <summary>
+/// The release tag IS the version: it is stamped into the assembly's version resource,
+/// plugin.json's `version` and VERSION.txt at the archive root. A tag MSBuild cannot parse either
+/// fails a release halfway through or is silently coerced - and coercion is the dangerous half,
+/// because two different tags then stamp the same version into every artefact.
+///
+/// WHY THIS EXISTS. The tags in this repository did not agree on a format. Measured 2026-09-11:
+/// v1.3.0, v1.1.1 and v1.0.7 lower-case; V1.2.8, V1.2.5, V1.2.2, V1.2.0 and V1.1.5 upper-case;
+/// and v10.4 with two components - which also sorts ABOVE every three-part tag in
+/// `git tag --sort=-v:refname`, so the newest-looking entry in the list was for ten days neither
+/// the newest release nor a valid version.
+///
+/// These tests drive the REAL script rather than a re-implementation of its regex, because a rule
+/// re-stated in a test is a rule that can agree with the test and disagree with the release. That
+/// is the trap CLAUDE.md records twice - "a tool tested against a plausible fixture is not
+/// tested" - and here the fixture would have been the pattern itself.
+///
+/// They also assert the MESSAGE, not just the exit code. The point of the script is telling a
+/// maintainer which of eight plausible mistakes they made; an exit code of 1 with unreadable text
+/// is a check that gets worked around rather than obeyed.
+/// </summary>
+public class ReleaseTagTests
+{
+    private static string ScriptPath()
+    {
+        var path = Res.FindRepoFile("scripts/Assert-ReleaseTag.ps1");
+        Assert.True(path is not null, "cannot find scripts/Assert-ReleaseTag.ps1");
+        return path!;
+    }
+
+    /// <summary>
+    /// Run the script the way the workflow does - powershell.exe -File - and return both streams
+    /// together, because the diagnosis goes to the host and the assertions below read it.
+    /// </summary>
+    private static (int ExitCode, string Output) Run(string tag)
+    {
+        var psi = new ProcessStartInfo("powershell.exe")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-ExecutionPolicy");
+        psi.ArgumentList.Add("Bypass");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(ScriptPath());
+        psi.ArgumentList.Add("-Tag");
+        psi.ArgumentList.Add(tag);
+
+        using var process = Process.Start(psi);
+        Assert.True(process is not null, "powershell.exe did not start");
+        var stdout = process!.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(120_000);
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    [Theory]
+    [InlineData("v1.3.0", "1.3.0")]
+    [InlineData("v0.0.0", "0.0.0")]          // the dev-build sentinel is still a legal tag
+    [InlineData("v12.7.31", "12.7.31")]
+    [InlineData("v10.0.0", "10.0.0")]        // two-digit major, the shape v10.4 should have had
+    [InlineData("refs/tags/v1.3.0", "1.3.0")] // GITHUB_REF as well as GITHUB_REF_NAME
+    public void AValidTagIsAcceptedAndItsVersionParsed(string tag, string version)
+    {
+        var (exit, output) = Run(tag);
+        Assert.True(exit == 0, $"'{tag}' was refused:{Environment.NewLine}{output}");
+        Assert.Contains($"version {version}", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// One case per plausible mistake, each asserting the text NAMES that mistake. A single
+    /// "refused" assertion would pass even if every message said the same unhelpful thing.
+    /// </summary>
+    [Theory]
+    [InlineData("V1.2.8", "upper-case")]
+    [InlineData("V1.2.0", "upper-case")]
+    [InlineData("1.2.3", "does not start with a lower-case")]
+    [InlineData("v10.4", "component(s) rather than 3")]
+    [InlineData("v2", "component(s) rather than 3")]
+    [InlineData("v1.2.3.4", "component(s) rather than 3")]
+    [InlineData("v1.2.3-rc1", "pre-release or build suffix")]
+    [InlineData("v1.2.3+build7", "pre-release or build suffix")]
+    [InlineData("v1.2.x", "not a decimal number")]
+    [InlineData("vone.two.three", "not a decimal number")]
+    [InlineData("v1.02.3", "leading zero")]
+    [InlineData("v01.2.3", "leading zero")]
+    [InlineData(" v1.2.3", "whitespace")]
+    [InlineData("release-1.2.3", "does not start with a lower-case")]
+    public void AnInvalidTagIsRefusedWithAMessageNamingTheActualMistake(string tag, string expected)
+    {
+        var (exit, output) = Run(tag);
+        Assert.True(exit == 1, $"'{tag}' should have been refused but exited {exit}");
+        Assert.Contains(expected, output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Every refusal must carry the four things that make it actionable without opening a file.
+    /// This is the part that decays first when a message is edited.
+    /// </summary>
+    [Theory]
+    [InlineData("V1.2.8")]
+    [InlineData("v10.4")]
+    [InlineData("v1.2.x")]
+    public void EveryRefusalNamesTheTagTheRuleAndTheRemedy(string tag)
+    {
+        var (exit, output) = Run(tag);
+        Assert.Equal(1, exit);
+        Assert.Contains(tag, output, StringComparison.Ordinal);
+        Assert.Contains("vX.Y.Z", output, StringComparison.Ordinal);
+        Assert.Contains("git tag -d", output, StringComparison.Ordinal);
+        Assert.Contains("git push origin", output, StringComparison.Ordinal);
+        Assert.Contains("Nothing has been built or published", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The near-miss suggestion is the most useful line in the message, and it must be a tag that
+    /// the script itself would then ACCEPT - a suggestion that is also invalid would send a
+    /// maintainer round the loop twice.
+    /// </summary>
+    [Theory]
+    [InlineData("V1.2.8", "v1.2.8")]
+    [InlineData("1.2.3", "v1.2.3")]
+    [InlineData("v10.4", "v10.4.0")]
+    [InlineData("v1.2.3-rc1", "v1.2.3")]
+    [InlineData("v1.02.3", "v1.2.3")]
+    public void TheSuggestedTagIsOfferedAndIsItselfValid(string tag, string suggestion)
+    {
+        var (exit, output) = Run(tag);
+        Assert.Equal(1, exit);
+        Assert.Contains($"you probably meant:  {suggestion}", output, StringComparison.Ordinal);
+
+        var (suggestedExit, suggestedOutput) = Run(suggestion);
+        Assert.True(suggestedExit == 0,
+            $"the script suggests '{suggestion}' for '{tag}' but then refuses it:"
+            + Environment.NewLine + suggestedOutput);
+    }
+
+    /// <summary>
+    /// The tags already in the repository, as a record of what this check would have caught. Not
+    /// a check on git - the list is inline on purpose, so it keeps documenting the motivation
+    /// after the tags themselves are cleaned up or deleted.
+    /// </summary>
+    [Fact]
+    public void TheExistingMalformedTagsInThisRepositoryWouldBeRefused()
+    {
+        foreach (var tag in new[] { "V1.2.8", "V1.2.5", "V1.2.2", "V1.2.0", "V1.1.5", "v10.4" })
+            Assert.Equal(1, Run(tag).ExitCode);
+
+        foreach (var tag in new[] { "v1.3.0", "v1.1.1", "v1.1.0", "v1.0.7", "v1.0.6" })
+            Assert.Equal(0, Run(tag).ExitCode);
+    }
+}

--- a/tests/LabVIEWMCP.Tests/Infra/ServerVersionTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/ServerVersionTests.cs
@@ -1,0 +1,135 @@
+using LabVIEWMcp.Infra;
+using LabVIEWMcp.Tests.Support;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Infra;
+
+/// <summary>
+/// Reading this build's own version. The input shapes are all produced by the build, so
+/// <see cref="ServerVersion.Read"/> is exercised directly - there is no way to make the running
+/// test assembly carry six different InformationalVersions.
+///
+/// The rule the tests encode: a version reader must NEVER throw. It is called by lvai_status and
+/// pylv_status, and those are the two tools someone reaches for when an install is already
+/// suspected of being broken. A reader that can fail there turns "your bundle is missing" into
+/// an unhandled exception with no diagnosis at all.
+/// </summary>
+public class ServerVersionTests
+{
+    [Fact]
+    public void AStampedReleaseVersionSplitsIntoItsVersionAndCommit()
+    {
+        var info = ServerVersion.Read("1.3.0+e08bf93921b708d94e32ceb6e519e5a3b58085cf");
+
+        Assert.Equal("1.3.0", info.Version);
+        Assert.Equal("e08bf93921b708d94e32ceb6e519e5a3b58085cf", info.Commit);
+        Assert.True(info.IsRelease);
+        Assert.Equal("1.3.0 (e08bf939)", info.Display);
+    }
+
+    /// <summary>
+    /// 0.0.0 is the csproj default and means "this did not come from the release workflow". The
+    /// distinction matters because until 2026-09-11 nothing set Version at all, so a release and
+    /// a local debug build both reported 1.0.0 - indistinguishable, which is exactly how three
+    /// installs on one machine came to be identifiable only by hashing 800 files.
+    /// </summary>
+    [Fact]
+    public void TheDevelopmentSentinelIsReportedAsADevBuild()
+    {
+        var info = ServerVersion.Read("0.0.0+4e71ce408c8f586c7a9e54b23d6eef8effe096fc");
+
+        Assert.Equal("0.0.0", info.Version);
+        Assert.False(info.IsRelease);
+        Assert.Contains("-dev", info.Display, StringComparison.Ordinal);
+        // The commit survives, and on a dev build it is the ONLY identifier there is.
+        Assert.Equal("4e71ce408c8f586c7a9e54b23d6eef8effe096fc", info.Commit);
+    }
+
+    [Fact]
+    public void AVersionWithNoCommitIsReadWithoutInventingOne()
+    {
+        var info = ServerVersion.Read("1.3.0");
+
+        Assert.Equal("1.3.0", info.Version);
+        Assert.Null(info.Commit);
+        Assert.True(info.IsRelease);
+        Assert.Contains("no commit recorded", info.Display, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("+")]                     // a trailing separator with nothing after it
+    [InlineData("+abc123")]               // a commit with no version
+    [InlineData("not-a-version")]
+    public void AnUnreadableInformationalVersionDegradesInsteadOfThrowing(string? informational)
+    {
+        var info = ServerVersion.Read(informational);
+
+        Assert.NotNull(info.Version);
+        Assert.NotEmpty(info.Version);
+        Assert.NotNull(info.Display);
+        // Whatever it is, it must not claim to be a release.
+        if (info.Version == "0.0.0") Assert.False(info.IsRelease);
+    }
+
+    /// <summary>
+    /// A short commit must not be sliced past its end - the Display property takes the first
+    /// eight characters and a hand-set or truncated SHA is the input that would throw.
+    /// </summary>
+    [Theory]
+    [InlineData("1.3.0+ab", "ab")]
+    [InlineData("1.3.0+abc1234", "abc1234")]
+    public void AShortCommitIsShownWholeRatherThanSliced(string informational, string commit)
+    {
+        var info = ServerVersion.Read(informational);
+
+        Assert.Equal(commit, info.Commit);
+        Assert.NotNull(info.Display);
+    }
+
+    /// <summary>
+    /// The real assembly, read the way the tools read it. It cannot assert a particular number -
+    /// that depends on how this build was invoked - only that the path works and produces
+    /// something a human can read.
+    /// </summary>
+    [Fact]
+    public void TheRunningAssemblyReportsAReadableVersion()
+    {
+        var info = ServerVersion.Current;
+
+        Assert.False(string.IsNullOrWhiteSpace(info.Version));
+        Assert.False(string.IsNullOrWhiteSpace(info.Display));
+        Assert.Same(info, ServerVersion.Current);   // cached, not re-read per call
+    }
+
+    /// <summary>
+    /// The csproj must carry an explicit Version, and it must be the 0.0.0 sentinel. Checked
+    /// against the file rather than the built assembly, because a build invoked with
+    /// -p:Version=X.Y.Z - which is what the release workflow does - would hide its absence.
+    /// </summary>
+    [Fact]
+    public void TheProjectDeclaresTheDevelopmentVersionSentinel()
+    {
+        var csproj = Res.FindRepoFile("src/LabVIEWMCP/LabVIEWMCP.csproj");
+        Assert.True(csproj is not null, "cannot find the project file");
+
+        Assert.Contains("<Version>0.0.0</Version>", File.ReadAllText(csproj!),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// plugin.json must carry the placeholder the release workflow substitutes. Without it the
+    /// stamping step fails the release - by design - but this says so at test time instead.
+    /// </summary>
+    [Fact]
+    public void ThePluginManifestCarriesTheVersionPlaceholder()
+    {
+        var manifest = Res.FindRepoFile("plugin/.claude-plugin/plugin.json");
+        Assert.True(manifest is not null, "cannot find plugin/.claude-plugin/plugin.json");
+
+        Assert.Contains("\"version\": \"0.0.0\"", File.ReadAllText(manifest!),
+            StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## TL;DR

every release ever published reported the SDK default `1.0.0`, same as a local debug build.

This PR fixes both halves:

- **Tags are validated.** `vX.Y.Z` only — lower-case `v`, three numbers. `scripts/Assert-ReleaseTag.ps1`
  runs first in the release workflow and refuses anything else with the specific mistake, why it
  matters, the intended tag and the retag commands. Five of the nine existing tags are upper-case
  (which the `v*` trigger ignores outright) and `v10.4` has two components.
- **Every install can say what it is.** The tag is stamped into the exe's version resource,
  `plugin.json` and a `VERSION.txt` at the archive root, and reported by `--version`, `lvai_status`
  and `pylv_status`. Plus a per-file manifest asset, so any install can be verified with no second
  install to compare against.

1667 tests pass (42 new). The README installer warning is removed — its premise doesn't hold.

---

A report that the plugin install "behaves differently" from the release-page download - specifically that its Python tooling was incomplete - was true as an observation and wrong as a diagnosis. Measured over one tag: the two routes are the same bytes by construction (the marketplace declares an `archive` source pointing at releases/latest/download/labview-mcp.zip), 732 files compared, every SHA-256 equal, the pylabview bundle byte-for-byte identical. The difference was version skew - a marketplace catalogue 13 days stale was serving a copy three releases behind.

Settling that took hashing 800 files, because nothing in an install carried a version: the csproj set no Version, so every release ever published reported the SDK default 1.0.0 and was indistinguishable from a local debug build. The commit SHA had been embedded the whole time (the SDK appends SourceRevisionId), so only the semantic half and the surfacing were missing.

Tag validation, the part that had to come first:

- scripts/Assert-ReleaseTag.ps1 accepts only vX.Y.Z - lower-case v, three decimal components - and is the FIRST step of the release workflow, so a bad tag costs seconds and publishes nothing. Each refusal names the actual mistake (upper-case V, missing v, two components, four, a -rc/+meta suffix, a non-numeric part, a leading zero), why it matters, the probable intended tag, and the delete-and-retag commands. Five of the nine existing tags are upper-case - which git treats as a different ref, so the v* trigger ignores them outright - and v10.4 has two components, which additionally sorts above every three-part tag in `git tag --sort=-v:refname`.
- Leading zeros are refused too: MSBuild reads 02 as 2, so v1.02.3 and v1.2.3 would stamp an identical version while remaining different git refs.
- ReleaseTagTests drives the real script rather than re-stating its regex, and asserts the message names the mistake and that each suggestion is itself accepted.

Version stamping and surfacing:

- <Version>0.0.0</Version> marks a build that did not come from the workflow; the workflow passes -p:Version=<tag> to the Release build and the publish, and asserts the stamp landed rather than assuming it.
- ServerVersion reads InformationalVersion; reported by a new --version flag, by lvai_status and by pylv_status - that last one because it is the only one that answers with no LabVIEW running, including on its notProvisioned path.
- plugin.json carries a 0.0.0 placeholder substituted at staging, so `claude plugin list` can identify the plugin.
- VERSION.txt at the archive root, because a file NAME dies at extraction: it is what lets a hand-extracted folder say what it is.

Release assets: the fixed-name labview-mcp.zip stays (the marketplace resolves it), plus a version-named copy, its SHA-256, and a per-file manifest that lets any install be verified with no second install to compare against.

Also: scripts/Compare-Installs.ps1, which is the comparison above, with a -ManifestPath mode and a negative control; docs/release-versioning.md with the measurements; and the README installer warning removed, since the premise behind it does not hold.

One defect found by dry-running the stamping step locally rather than trusting it: the readback used `Get-Content -Raw`, which decodes a BOM-less file with the system ANSI codepage on Windows PowerShell, turning the non-ASCII author name to mojibake. Every read and write in that step now states its encoding, and the result is asserted byte-identical to what was meant.