### PR TITLE
Reject a hand-cut release, and stage README.md in the archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,16 @@ jobs:
           Copy-Item -Path '.claude/settings.json' -Destination (Join-Path $staging 'bin/claude') -Force
           Copy-Item -Path 'CLAUDE.md'             -Destination (Join-Path $staging 'bin/claude') -Force
 
+          # README.md beside the exe, as bin/README.md. The .csproj stages it next to the exe in a
+          # LOCAL build (<None Include="..\..\README.md" Link="README.md">) and this step did not,
+          # so a plugin install was the one install route with no README at all - while CLAUDE.md
+          # asserted flatly that "the build copies all of docs\ and README.md next to the exe".
+          # True of the csproj, false of the release archive, and nothing compared the two. Found
+          # 2026-09-11 while auditing this file against build.ps1's output. `bin/` rather than the
+          # archive root for the same reason claude/ and docs/ are there: "beside the exe" is the
+          # layout invariant the rest of this step keeps.
+          Copy-Item -Path 'README.md' -Destination (Join-Path $staging 'bin/README.md') -Force
+
           Write-Host "Staging tree:"
           $root = (Resolve-Path $staging).Path
           # The bundle is 636 files of interpreter and stdlib; listing them buries everything else,
@@ -521,3 +531,27 @@ jobs:
             labview-mcp.sha256
             labview-mcp.manifest.sha256
           fail_on_unmatched_files: true
+
+      # 8. Read back what was actually PUBLISHED, over the network, as any user would. Every step
+      #    above checked the staging tree; this is the first one that checks the release - it
+      #    re-downloads labview-mcp.zip from the Releases page, verifies its digest against the
+      #    published labview-mcp.sha256 and every one of its ~800 entries against the published
+      #    manifest, and confirms the uploader is github-actions[bot].
+      #
+      #    Cheap insurance against a partial or reordered upload. The same script runs daily from
+      #    verify-release.yml, which is what catches an asset REPLACED by hand after the fact -
+      #    the failure this repository actually had, five times.
+      - name: Verify what was published
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Two attempts: an asset can still be settling immediately after the upload step.
+          for ($attempt = 1; $attempt -le 2; $attempt++) {
+            powershell -NoProfile -ExecutionPolicy Bypass `
+              -File scripts/Assert-PublishedRelease.ps1 `
+              -Repo '${{ github.repository }}' -Tag '${{ steps.tag.outputs.tag }}' -Token $env:GH_TOKEN
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            if ($attempt -eq 1) { Write-Host 'retrying in 30s'; Start-Sleep -Seconds 30 }
+          }
+          throw 'the release was published but does not verify - see the FAIL lines above'

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,90 @@
+name: verify-release
+
+# Check that what is PUBLISHED is what the release workflow produced.
+#
+# WHY THIS IS A SEPARATE WORKFLOW. release.yml can only vouch for releases it cut. The failure it
+# cannot see is a release cut BY HAND, and that is the one that actually happened: measured
+# 2026-09-11 over this repository's own release history, five releases - V1.1.5, V1.2.0, V1.2.2,
+# V1.2.5, V1.2.8 - carry a `labview-mcp.zip` uploaded by a person rather than by
+# github-actions[bot], at 19-21 MB against CI's 62 MB. Opening V1.2.8's asset settles what it is:
+# a zip of src\LabVIEWMCP\bin\Debug\net8.0 - exe and 46 loose DLLs at the archive root, no
+# .claude-plugin/plugin.json, no .mcp.json, no agents/, and a pylabview bundle built from a
+# developer's own Python 3.14 (the version release.yml pins away from, because it emits three
+# SyntaxWarnings from LVheap.py on every import).
+#
+# Those tags are upper-case, which the `v*` filter on release.yml ignores case-sensitively, so no
+# CI asset ever existed to publish. scripts\Assert-ReleaseTag.ps1 now removes that trigger. This
+# removes the consequence: for four days /releases/latest/download/labview-mcp.zip - the URL the
+# marketplace resolves for every plugin install - pointed at a hand-cut archive, which is what the
+# README's "there is currently a problem with the installer" banner was describing.
+#
+# The daily schedule is the part that matters. An asset can be replaced on an existing release at
+# any time, long after any workflow ran, so the only reliable guard is to keep looking.
+
+on:
+  release:
+    # `published` covers a release created as published or promoted from draft; `edited` and
+    # `released` cover a later change to an existing one - which is exactly how an asset gets
+    # swapped after the fact.
+    types: [published, edited, released, created, prereleased]
+  schedule:
+    # Daily. Not on the hour, so it is not queued behind everyone else's cron.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to check (blank = whatever /releases/latest returns)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    # windows-latest for parity with release.yml and with every other script in this repository;
+    # the check itself is plain .NET and would run anywhere pwsh does.
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The tag to check, by trigger:
+      #   release event      -> the release that fired it
+      #   workflow_dispatch  -> the input, if given
+      #   schedule           -> blank, so the script checks /releases/latest, which is what the
+      #                         marketplace resolves and therefore what every install receives
+      - name: Decide which release to check
+        id: which
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.release.tag_name }}'
+          if (-not $tag) { $tag = '${{ inputs.tag }}' }
+          if ($tag) { Write-Host "checking tag $tag" } else { Write-Host 'checking /releases/latest' }
+          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      # Retried, because a release event can fire while the 63 MB assets are still uploading - the
+      # asset set would then be incomplete through no fault of the publisher. Three attempts a
+      # minute apart; a hand-cut release still fails all three, and this costs nothing when the
+      # first one passes.
+      - name: Verify the published release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tagArg = @()
+          if ('${{ steps.which.outputs.tag }}') { $tagArg = @('-Tag', '${{ steps.which.outputs.tag }}') }
+
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            Write-Host "--- attempt $attempt of 3"
+            powershell -NoProfile -ExecutionPolicy Bypass `
+              -File scripts/Assert-PublishedRelease.ps1 `
+              -Repo '${{ github.repository }}' -Token $env:GH_TOKEN @tagArg
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            if ($attempt -lt 3) {
+              Write-Host 'not yet - the assets may still be uploading; waiting 60s'
+              Start-Sleep -Seconds 60
+            }
+          }
+          throw 'the published release did not verify - see the FAIL lines above'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1350,6 +1350,7 @@ literally it argued away 600 usable palette VIs.
 | Why did a tool call fail with no detail? | `docs/tool-argument-errors.md` | — |
 | WHICH RELEASE is this install, and do the plugin and the zip differ? | `docs/release-versioning.md` | `LabVIEWMCP --version`, `lvai_status`/`pylv_status` (`serverVersion`), `scripts/Compare-Installs.ps1` |
 | What must a release TAG look like? | `docs/release-versioning.md` §4 | `scripts/Assert-ReleaseTag.ps1` |
+| Is what is PUBLISHED actually the workflow's artefact? | `docs/release-versioning.md` §2a, §2b | `scripts/Assert-PublishedRelease.ps1` |
 | How do I generate a VI in one call? | `docs/bulk-operations.md` | `lvai_generate_vi` |
 | How do I run a whole pylabview edit in one call? | `docs/bulk-operations.md` | `pylv_apply` |
 | When is pylabview the route, not AIXML? | `experiments/pylabview/ROUTING.md` (source tree only) | `pylv_route` |
@@ -1402,6 +1403,15 @@ every row resolves. The eight served documents stay embedded as well: a tool ans
 on a file beside the exe surviving. Nothing about `docs\` needs a `.csproj` edit any more — the glob
 takes new files automatically, and `NoCustomerOrProductIdentifiersAnywhereInTheDocsFolder` walks the
 folder so a new document is covered by the confidentiality guard the moment it exists.
+
+**"THE BUILD" IN THAT SENTENCE MEANT THE `.csproj`, AND THE RELEASE ARCHIVE IS A SEPARATE LIST.**
+Audited 2026-09-11: the csproj stages `README.md` next to the exe and `release.yml`'s staging step
+did not, so a plugin install was the one route with no `README.md` at all — while the paragraph
+above asserted flatly that the build copies it. Fixed in the workflow (`bin/README.md`), and the
+lesson is the one this section already teaches one layer in: **there are now TWO lists of what
+ships** — the `.csproj` globs for a local build, and the staging step for the archive — and a file
+added to one is not in the other. `docs\` and `scripts\` are globbed in both; everything named
+individually (`README.md`, `CLAUDE.md`, `.claude\settings.json`) has to be added twice.
 
 **`experiments/` still ships nothing** — absent from the `.csproj`, embedded and copied alike, and
 `pylv_route`/`pylv_status` only *mention* `ROUTING.md` and `FINDINGS.md` in code comments rather than
@@ -1532,6 +1542,31 @@ identifying an install meant hashing 800 files. The commit SHA had been embedded
 nothing serves. It is now reported by `--version`, by `lvai_status` and by `pylv_status`, that last
 one because it is the only one that answers with no LabVIEW running.
 
+**NEVER PUBLISH `build.ps1`'s OUTPUT — and that is not a style rule, it happened five times.**
+Measured 2026-09-11 off the GitHub API: `V1.1.5`, `V1.2.0`, `V1.2.2`, `V1.2.5` and `V1.2.8` carry a
+`labview-mcp.zip` uploaded by a PERSON, 19-21 MB against CI's 62 MB, and V1.2.8's asset opened is a
+zip of `src\LabVIEWMCP\bin\Debug\net8.0` — exe and 46 loose DLLs at the archive ROOT, no
+`.claude-plugin\plugin.json`, no `.mcp.json`, no `agents\`, a framework-dependent apphost that does
+not start without the .NET 8 runtime, and a pylabview bundle off a workstation's **Python 3.14**,
+the version `release.yml` pins away from because it emits SyntaxWarnings from `LVheap.py` on every
+import. For four days `/releases/latest/download/labview-mcp.zip` served one of those to every
+plugin install, which is what the README's "problem with the installer" banner was describing.
+`scripts/Assert-PublishedRelease.ps1` rejects one now, run per release event and **daily** by
+`.github/workflows/verify-release.yml` — daily because an asset can be swapped long after any
+workflow ran.
+
+**The process lesson generalises past releases: A PIPELINE GUARANTEE IS NOT A PROPERTY OF THE
+ARTEFACT.** "There is one build and one packaging path" was true of the workflow and said nothing
+about what sat on the Releases page. Reading `uploader.login` off the API settled in one call what
+reasoning about the pipeline had hidden for four days. **Ask the artefact, not the process that is
+supposed to have made it** — the same rule as "ask the file, not the session".
+
+**AND THERE ARE TWO LISTS OF WHAT SHIPS.** The `.csproj` globs decide a local build's output; the
+staging step in `release.yml` decides the archive. `docs\` and `scripts\` are globbed in both, so a
+new file reaches both by itself — everything named individually (`README.md`, `CLAUDE.md`,
+`.claude\settings.json`) must be added TWICE. `README.md` was in only one, so a plugin install was
+the one route without it while this file asserted the opposite.
+
 **THE PLUGIN AND THE RELEASE ZIP ARE THE SAME BYTES — stop looking for a packaging difference.**
 `.claude-plugin/marketplace.json` declares the plugin as an `archive` source pointing at
 `releases/latest/download/labview-mcp.zip`, so a store install IS that asset unpacked: one build,
@@ -1541,6 +1576,11 @@ that a marketplace catalogue does not refresh itself — one 13 days stale was s
 releases behind. `claude plugin marketplace update` then `claude plugin update`. The one real
 asymmetry is extraction: Explorer's "Extract All" propagates Mark-of-the-Web onto the bundled
 `python.exe`, so extract with `tar -xf`.
+
+**QUALIFIED THE SAME DAY IT WAS WRITTEN: that holds for an asset the WORKFLOW produced, and five
+were not** — see the hand-cut releases above. Both installs behind the 732-file measurement came
+from bot-uploaded tags (v1.3.0 and v1.0.7), which was luck rather than method. So the order is:
+check the **uploader and the tag** first, and only then reach for a byte comparison.
 
 **The recovery is `rm -rf src/LabVIEWMCP/obj src/LabVIEWMCP/bin tests/LabVIEWMCP.Tests/obj
 tests/LabVIEWMCP.Tests/bin` and a normal build.** If you want a type-check while the server holds

--- a/README.md
+++ b/README.md
@@ -1013,7 +1013,35 @@ On the tag push, the workflow runs on `windows-latest` and:
     never to be renamed), `labview-mcp-vX.Y.Z.zip` (the same bytes, self-identifying, for a human
     download), `labview-mcp.sha256`, and `labview-mcp.manifest.sha256` — path plus SHA-256 of every
     file in the archive, which is what lets any install be verified with no second install to
-    compare against.
+    compare against;
+12. **re-downloads what it just published and verifies it**, over the network, as a user would —
+    digest against the published `labview-mcp.sha256`, every entry against the published manifest,
+    and the uploader against `github-actions[bot]`. Every step before this one checks the staging
+    tree; this is the first that checks the release.
+
+### Never cut a release by hand
+
+Not a style rule — it happened five times. `V1.1.5`, `V1.2.0`, `V1.2.2`, `V1.2.5` and `V1.2.8` each
+carry a `labview-mcp.zip` **uploaded by a person**, 19–21 MB against CI's 62 MB, because the
+uppercase tag meant the workflow never ran and the release was then built locally and uploaded.
+Opening `V1.2.8`'s asset: it is a zip of `src\LabVIEWMCP\bin\Debug\net8.0\` — the exe and 46 loose
+DLLs at the archive root, **no `.claude-plugin/plugin.json`, no `.mcp.json`, no `agents/`**, a
+framework-dependent apphost that will not start without the .NET 8 runtime, and a pylabview bundle
+off a workstation's **Python 3.14** (the version the workflow pins away from, because it emits
+SyntaxWarnings from `LVheap.py` on every import). For four days
+`/releases/latest/download/labview-mcp.zip` served it to every plugin install.
+
+[`.github/workflows/verify-release.yml`](.github/workflows/verify-release.yml) now rejects one — on
+every release event and on a **daily schedule**, because an asset can be replaced on an existing
+release long after any workflow has finished. Run the same check yourself at any time:
+
+```bash
+powershell -ExecutionPolicy Bypass -File scripts/Assert-PublishedRelease.ps1
+```
+
+With no arguments it checks whatever `/releases/latest` returns — the release the marketplace hands
+to every install. `-Tag vX.Y.Z` checks one, and `-ZipPath <file>` checks an archive on disk with no
+network at all. `docs/release-versioning.md` §2a–2b has the measurements.
 
 The asset is about 38 MB larger since step 5 was added.
 

--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,28 @@
     restart a killed MCP server inside a session: the lvai_* tools stay gone until the
     Claude client is restarted.
 
+    THIS OUTPUT IS A DEVELOPMENT BUILD AND MUST NEVER BE PUBLISHED AS A RELEASE.
+    Zipping bin\Debug\net8.0 and uploading it is not "the same thing built locally" — it
+    differs from the release archive in five ways that each break an install, measured
+    2026-09-11 by downloading a release that had been cut exactly that way:
+
+      - it carries NO .claude-plugin\plugin.json, NO .mcp.json, NO plugin-flavoured
+        agents\ and NO hooks\, so it is not installable as a plugin at all;
+      - the exe sits at the ROOT, while plugin\.mcp.json launches
+        ${CLAUDE_PLUGIN_ROOT}/bin/LabVIEWMCP.exe;
+      - the exe is FRAMEWORK-DEPENDENT (a 151 kB apphost plus ~46 loose DLLs), so it does
+        not start without the .NET 8 runtime installed, where the release exe is
+        self-contained and single-file;
+      - it is Debug, unstamped, and reports 0.0.0-dev from --version;
+      - the pylabview bundle is whatever this machine happens to have — the ItemGroup that
+        copies it is conditional on tools\pylabview\runtime existing at all, and the one
+        release cut this way shipped a Python 3.14 bundle that emits SyntaxWarnings from
+        LVheap.py on every pylv_* call, against the pinned 3.12 the workflow provisions.
+
+    Releases are cut ONLY by pushing a vX.Y.Z tag. scripts\Assert-PublishedRelease.ps1
+    and .github\workflows\verify-release.yml now reject a hand-cut one; see
+    docs\release-versioning.md.
+
 .PARAMETER NoKill
     Fail instead of stopping a running server.
 
@@ -158,4 +180,7 @@ if ($VerifyOnly) {
     Write-Host 'Embedded documentation verified. The binary-only install answers correctly.' -ForegroundColor Green
 } else {
     Write-Host 'Done. Restart the Claude client to pick the server back up.' -ForegroundColor Green
+    # Said where somebody about to zip this folder would be looking. Five releases were cut that
+    # way and none of them was installable as a plugin; see this script's .DESCRIPTION.
+    Write-Host 'This is a DEVELOPMENT build - never publish it as a release. Push a vX.Y.Z tag.' -ForegroundColor DarkGray
 }

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -18,6 +18,13 @@ That is the asset on the Releases page. There is one build, one packaging path a
 a difference between a store install and a hand-extracted zip can only be **version skew** or a
 **damaged copy** — never a different build. The release workflow has no second branch.
 
+**That holds only for an asset the workflow actually produced, and five were not.** Read literally
+it says the packaging cannot differ, and §2a is five counterexamples: releases whose
+`labview-mcp.zip` was built locally and uploaded by hand. Nothing about the pipeline was wrong;
+the pipeline had simply not run. Corrected 2026-09-11, the same day this section was written —
+which is why `scripts/Assert-PublishedRelease.ps1` now checks the published artefact instead of
+reasoning about it from the workflow.
+
 Confirmed file by file over the same tag (v1.3.0), a plugin cache install against a `tar -xf`
 extract of the asset:
 
@@ -57,6 +64,89 @@ What that older copy was missing looks exactly like "the plugin ships less":
 
 The pylabview bundle was **not** among the differences. The fix is
 `claude plugin marketplace update zuehlke-labview` followed by `claude plugin update labview-mcp`.
+
+## 2a. And a second cause: five releases were cut by hand
+
+§2 explains the stale *catalogue*. It does not explain why a user who updated correctly could still
+get something broken, and this does. The GitHub API records who uploaded each asset, and the split
+is exact:
+
+| tag | uploader | asset | size |
+|---|---|---|---|
+| `v1.3.0`, `v1.1.1`, `v1.1.0`, `v1.0.7`, `v1.0.6` … | `github-actions[bot]` | `labview-mcp.zip` | 62.3–62.9 MB |
+| **`V1.1.5`, `V1.2.0`, `V1.2.2`, `V1.2.5`, `V1.2.8`** | **a person** | `labview-mcp.zip` | 19.3–20.9 MB |
+| `V0.8.5`, `V0.7.8`, `V0.7.0` | a person | `LabVIEWMCP_V<tag>.zip` | 2.8 MB |
+
+Every upper-case tag is a hand-cut release. The mechanism is the one `Assert-ReleaseTag.ps1` now
+blocks: the workflow triggers on `v*`, GitHub matches refs case-sensitively, so an upper-case tag
+built nothing — and the release was then produced locally and uploaded.
+
+**`V1.2.8`'s asset, downloaded and opened, is a zip of `src\LabVIEWMCP\bin\Debug\net8.0\`.**
+Measured 2026-09-11, 1 006 entries:
+
+| | the hand-cut archive | the workflow's archive |
+|---|---|---|
+| `.claude-plugin/plugin.json` | **absent** → not installable as a plugin | at the root |
+| `.mcp.json` | **absent** → nothing launches the server | at the root |
+| plugin-flavoured `agents/`, `hooks/` | **absent** | at the root |
+| the exe | at the **root**, a 151 kB apphost + **46 loose DLLs**, `.pdb`, `deps.json`, `runtimes/` — framework-dependent, so it does not start without the .NET 8 runtime | `bin/LabVIEWMCP.exe`, self-contained single file |
+| pylabview bundle | at `pylabview/`, **Python 3.14**, `provisionedFrom: C:\Users\<person>\AppData\Local\Programs\Python\Python314`, provisioned 2026-08-25 and reused for every later hand-cut release | `bin/pylabview/`, pinned **3.12**, provisioned per release from the runner tool cache |
+| `VERSION.txt` | absent | at the root |
+
+`plugin/.mcp.json` launches `${CLAUDE_PLUGIN_ROOT}/bin/LabVIEWMCP.exe`, which that layout does not
+have; and with no `plugin.json` at the root the archive cannot be installed at all. Between
+2026-09-07 and 2026-09-11 the newest published release was one of these, so
+`/releases/latest/download/labview-mcp.zip` — the URL the marketplace resolves — served it to every
+plugin install. **That is what the README's "there is currently a problem with the installer"
+banner was describing, and the banner was not wrong.**
+
+**The Python 3.14 row is the one that answers the original report.** `release.yml` pins 3.12 with
+the comment *"3.14 also works — measured — but emits three SyntaxWarnings from pylabview's own
+LVheap.py on every import, and those are noise in every `pylv_*` answer."* So the Python tooling
+really did behave differently between the two routes — not because the plugin route packaged less,
+but because a hand-cut release shipped a different interpreter.
+
+**Both installs measured in §1 happened to be CI-built, and that was luck.** They came from v1.3.0
+and v1.0.7, both `github-actions[bot]`. Had either been one of the five, §1's conclusion would have
+come out the other way — which is the argument for checking the uploader *first*, before hashing
+anything.
+
+## 2b. What now rejects a hand-cut release
+
+`scripts/Assert-PublishedRelease.ps1`, run by `.github/workflows/verify-release.yml` on every
+release event and on a **daily schedule**, and as the last step of `release.yml` against the
+release it has just cut. The daily run is the part that matters: an asset can be replaced on an
+existing release at any time, long after any workflow has finished.
+
+It downloads what is published and checks, in this order:
+
+| check | what it catches |
+|---|---|
+| the asset is named `labview-mcp.zip` | `LabVIEWMCP_V0.8.5.zip` — a 404 for every plugin install |
+| `labview-mcp.sha256`, `labview-mcp.manifest.sha256` and `labview-mcp-<tag>.zip` are present | an asset set the workflow does not produce |
+| the tag is a valid `vX.Y.Z` | the upper-case tag that left no CI asset to publish |
+| **the uploader is `github-actions[bot]`** | a hand-cut release, whatever the archive looks like |
+| the archive matches its published SHA-256 | an asset replaced after it was hashed |
+| `.claude-plugin/plugin.json`, `.mcp.json`, `VERSION.txt`, `bin/LabVIEWMCP.exe`, `bin/pylabview/python.exe`, `agents/*.md` are present | the plugin shape |
+| **no loose `*.dll`/`*.pdb`/`deps.json` and no `LabVIEWMCP.exe` at the archive root** | the direct signature of a zipped `bin\Debug\net8.0` |
+| `VERSION.txt`'s `tag:` and `version:` match the release; a 40-hex `commit:` | an archive from a different run |
+| `plugin.json`'s `version` is the tag and not `0.0.0` | the placeholder never substituted |
+| the bundle is Python **3.12** and `provisionedFrom` is not under `\Users\` | a bundle off somebody's workstation |
+| every archive entry matches the published manifest | any missing, extra or altered file |
+
+Against the live v1.4.1 it reports 21 checks green including all 807 entries; against the real
+V1.2.8 asset, 11 failures naming each cause. `-ZipPath` runs it offline against an archive on disk,
+which is what `PublishedReleaseTests` drives — a good fixture shaped from v1.4.1, a bad one shaped
+from V1.2.8, and one-change mutations for each individual check.
+
+Two things it found while being written, both worth keeping:
+
+- **`bundle.json` carries a UTF-8 BOM** (provision.ps1 writes it through `Out-File`) and Windows
+  PowerShell's `ConvertFrom-Json` rejects one with `Invalid JSON primitive: .`. It crashed on the
+  first run against the live archive while passing every BOM-less fixture, so the fixture now has
+  a BOM.
+- **`"a" + $array -join ', '`** binds as `("a" + $array) -join ', '` in PowerShell and silently
+  produces the wrong message text. Two of the failure messages had it.
 
 ## 3. The identifiers, and which of them already existed
 
@@ -191,3 +281,19 @@ answering "which build is this?" still took an afternoon — because nothing sur
 number that was surfaced (`1.0.0`) was the same for every build ever made. **A value that exists
 but is not reported is not an answer**, which is the same shape as this repository's
 embedded-but-unshipped documents: present in the artefact, reachable by nobody.
+
+**And the second lesson is sharper, because §1 was written confidently and was incomplete: a
+PIPELINE GUARANTEE IS NOT A PROPERTY OF THE ARTEFACT.** "There is one build and one packaging path"
+was true of the workflow and said nothing about what was on the Releases page, because five assets
+had never been through it. Reasoning from the pipeline is what made a four-day outage invisible for
+four days; the check that settled it in one call was reading `uploader.login` off the API. **Ask the
+artefact, not the process that is supposed to have made it** — the same rule this repository already
+records as "ask the file, not the session".
+
+**A corollary worth naming, since it caused the one gap found in the same audit: there are TWO
+lists of what ships.** The `.csproj` globs decide a local build's output; the staging step in
+`release.yml` decides the archive. `docs\` and `scripts\` are globbed in both, so a new file lands
+in both automatically — but everything named individually has to be added twice, and `README.md`
+had been added to only one. A plugin install was therefore the single route with no `README.md`
+while `CLAUDE.md` asserted flatly that "the build copies all of `docs\` and `README.md` next to the
+exe". Now staged as `bin/README.md`.

--- a/scripts/Assert-PublishedRelease.ps1
+++ b/scripts/Assert-PublishedRelease.ps1
@@ -1,0 +1,405 @@
+<#
+.SYNOPSIS
+    Verify that what is actually PUBLISHED on the Releases page is what the release workflow
+    produced - and refuse a hand-cut release.
+
+.DESCRIPTION
+    THE INCIDENT THIS EXISTS FOR, measured 2026-09-11 against the repository's own release history.
+    Five releases - V1.1.5, V1.2.0, V1.2.2, V1.2.5, V1.2.8 - carry a `labview-mcp.zip` uploaded by a
+    PERSON rather than by github-actions[bot], at 19-21 MB against CI's 62 MB. Downloading V1.2.8's
+    asset and opening it settles what it is: a zip of `src\LabVIEWMCP\bin\Debug\net8.0\`.
+
+      - LabVIEWMCP.exe at the archive ROOT (151 KB apphost), plus 48 loose dependency DLLs, a .pdb,
+        LabVIEWMCP.deps.json, runtimeconfig.json and runtimes\ - i.e. FRAMEWORK-DEPENDENT, so it does
+        not start at all without the .NET 8 runtime installed.
+      - NO .claude-plugin/plugin.json, NO .mcp.json, NO agents/, NO hooks/ - so it is not installable
+        as a plugin, and `plugin/.mcp.json`'s `${CLAUDE_PLUGIN_ROOT}/bin/LabVIEWMCP.exe` resolves to
+        nothing.
+      - a pylabview bundle built from `C:\Users\<person>\AppData\Local\Programs\Python\Python314`,
+        provisioned 2026-08-25 and reused for every hand-cut release afterwards. Python **3.14** is
+        the version release.yml pins AWAY from, because it emits three SyntaxWarnings from
+        pylabview's own LVheap.py on every import - so the Python tooling really did behave
+        differently between the two routes, which is what was originally reported.
+
+    Between 2026-09-07 and 2026-09-11 the newest published release was one of those, and
+    `/releases/latest/download/labview-mcp.zip` - the URL the marketplace resolves - pointed at it.
+    The README carried an "there is currently a problem with the installer" banner for exactly that
+    reason.
+
+    scripts\Assert-ReleaseTag.ps1 removes the trigger (the upper-case tag the `v*` workflow filter
+    ignored, which is what left no CI asset to publish). It does NOT stop anyone uploading an asset
+    by hand, and this does: it reads what is published and fails loudly.
+
+    Run by .github\workflows\verify-release.yml on every release event and on a daily schedule, and
+    as the last step of release.yml against the release it has just cut.
+
+.PARAMETER Repo
+    owner/name to query. Default: this repository.
+
+.PARAMETER Tag
+    Which release to check. Default: whatever `/releases/latest` returns - deliberately, because
+    that is the release the marketplace hands to every plugin install.
+
+.PARAMETER Token
+    Optional GitHub token, to lift the unauthenticated rate limit. CI passes GITHUB_TOKEN.
+
+.PARAMETER ZipPath
+    OFFLINE mode: check this archive instead of downloading one. The API checks (asset set,
+    uploader) are skipped and reported as skipped. This is what the tests drive, and it is also how
+    to check an archive somebody handed you.
+
+.PARAMETER ManifestPath
+    Offline mode: labview-mcp.manifest.sha256 to compare the archive against. Optional.
+
+.PARAMETER Sha256Path
+    Offline mode: labview-mcp.sha256 to compare the archive's digest against. Optional.
+
+.PARAMETER Uploader
+    Offline mode: the login that uploaded the archive, when you know it. Optional.
+
+.PARAMETER KeepDownload
+    Do not delete the downloaded archive. Useful when a check failed and you want to look.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File scripts\Assert-PublishedRelease.ps1
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File scripts\Assert-PublishedRelease.ps1 -Tag v1.4.1
+
+.EXAMPLE
+    # An archive already on disk, with no network at all:
+    powershell -ExecutionPolicy Bypass -File scripts\Assert-PublishedRelease.ps1 -ZipPath .\labview-mcp.zip -Tag v1.4.1
+#>
+[CmdletBinding()]
+param(
+    [string]$Repo = 'Zuehlke/labview-mcp',
+    [string]$Tag,
+    [string]$Token,
+    [string]$ZipPath,
+    [string]$ManifestPath,
+    [string]$Sha256Path,
+    [string]$Uploader,
+    [switch]$KeepDownload
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$CiUploader = 'github-actions[bot]'
+$Utf8 = [Text.UTF8Encoding]::new($false)
+
+$failures = New-Object System.Collections.Generic.List[string]
+$passes   = New-Object System.Collections.Generic.List[string]
+$skips    = New-Object System.Collections.Generic.List[string]
+
+function Ok   { param([string]$m) $passes.Add($m) }
+function Bad  { param([string]$m) $failures.Add($m) }
+function Skip { param([string]$m) $skips.Add($m) }
+
+# ---------------------------------------------------------------------------------------------
+# Small helpers over the archive. Entries are read through the zip rather than extracted: the
+# archive is 62 MB of mostly interpreter, and only a handful of small files are actually read.
+# ---------------------------------------------------------------------------------------------
+
+function Get-EntryText {
+    param($Zip, [string]$Name)
+    $entry = $Zip.Entries | Where-Object { $_.FullName -eq $Name }
+    if (-not $entry) { return $null }
+    $stream = $entry.Open()
+    try {
+        $memory = New-Object System.IO.MemoryStream
+        $stream.CopyTo($memory)
+        $text = $Utf8.GetString($memory.ToArray())
+        # Strip a leading BOM. UTF8Encoding does not remove it, and Windows PowerShell's
+        # ConvertFrom-Json then fails with "Invalid JSON primitive: ." on a perfectly good file.
+        # Measured against the real v1.4.1 archive: bundle.json carries a BOM (provision.ps1 writes
+        # it through Out-File) while plugin.json does not, so the fault appeared only on the second
+        # of the two files this reads.
+        return $text.TrimStart([char]0xFEFF)
+    } finally { $stream.Dispose() }
+}
+
+function Get-EntryHashes {
+    param($Zip)
+    $table = @{}
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        foreach ($entry in $Zip.Entries) {
+            # Directory entries have an empty name after the trailing slash; the manifest holds
+            # files only, so they must not be compared.
+            if ($entry.FullName.EndsWith('/')) { continue }
+            $stream = $entry.Open()
+            try {
+                $table[$entry.FullName] =
+                    [BitConverter]::ToString($sha.ComputeHash($stream)).Replace('-', '').ToLowerInvariant()
+            } finally { $stream.Dispose() }
+        }
+    } finally { $sha.Dispose() }
+    return $table
+}
+
+function Read-ManifestRows {
+    param([string]$Path)
+    $table = @{}
+    foreach ($line in [IO.File]::ReadAllLines($Path, $Utf8)) {
+        if ($line -match '^([0-9a-fA-F]{64})\s\s?(.+)$') {
+            $table[$Matches[2].Trim()] = $Matches[1].ToLowerInvariant()
+        }
+    }
+    return $table
+}
+
+# ---------------------------------------------------------------------------------------------
+# 1. Resolve what to check: either an archive on disk, or the published release.
+# ---------------------------------------------------------------------------------------------
+
+$downloaded = $null
+$assets = $null
+
+if ($ZipPath) {
+    if (-not (Test-Path -LiteralPath $ZipPath)) { throw "no such archive: $ZipPath" }
+    $archive = (Resolve-Path -LiteralPath $ZipPath).Path
+    Skip 'the asset set and the uploader (offline mode - nothing was queried)'
+    Write-Host "offline: $archive"
+} else {
+    $headers = @{ 'User-Agent' = 'labview-mcp-release-check'; 'Accept' = 'application/vnd.github+json' }
+    if ($Token) { $headers['Authorization'] = "Bearer $Token" }
+
+    $url = if ($Tag) { "https://api.github.com/repos/$Repo/releases/tags/$Tag" }
+           else       { "https://api.github.com/repos/$Repo/releases/latest" }
+    Write-Host "querying $url"
+    $release = Invoke-RestMethod -Uri $url -Headers $headers
+
+    if (-not $Tag) { $Tag = $release.tag_name }
+    $assets = @($release.assets)
+    Write-Host "release $($release.tag_name), published $($release.published_at), $($assets.Count) asset(s)"
+    foreach ($a in $assets) {
+        Write-Host ("  {0,-34} uploader={1,-22} {2,11} bytes" -f $a.name, $a.uploader.login, $a.size)
+    }
+
+    # The FIXED name, because that is the one the marketplace resolves. A release carrying only a
+    # version-named copy is a release no plugin install can fetch.
+    $zipAsset = $assets | Where-Object { $_.name -eq 'labview-mcp.zip' } | Select-Object -First 1
+    if (-not $zipAsset) {
+        Bad ("the release has no asset named 'labview-mcp.zip'. The marketplace resolves " +
+             "/releases/latest/download/labview-mcp.zip, so nothing can install this release. " +
+             "V0.8.5, V0.7.8 and V0.7.0 shipped as 'LabVIEWMCP_V<tag>.zip' and were a 404 for " +
+             'every plugin install.')
+        # Nothing further is checkable.
+        $archive = $null
+    } else {
+        $Uploader = $zipAsset.uploader.login
+        $downloaded = Join-Path ([IO.Path]::GetTempPath()) ("labview-mcp-check-" + [guid]::NewGuid().ToString('N') + '.zip')
+        Write-Host "downloading $($zipAsset.browser_download_url)"
+        Invoke-WebRequest -Uri $zipAsset.browser_download_url -OutFile $downloaded -Headers @{ 'User-Agent' = 'labview-mcp-release-check' }
+        $archive = $downloaded
+
+        foreach ($name in @('labview-mcp.sha256', 'labview-mcp.manifest.sha256', "labview-mcp-$Tag.zip")) {
+            if ($assets.name -contains $name) { Ok "the release carries $name" }
+            else { Bad "the release has no '$name' asset - the workflow attaches it, so this release did not come from the workflow" }
+        }
+
+        foreach ($helper in @(@{ N = 'labview-mcp.sha256'; V = 'Sha256Path' },
+                              @{ N = 'labview-mcp.manifest.sha256'; V = 'ManifestPath' })) {
+            $asset = $assets | Where-Object { $_.name -eq $helper.N } | Select-Object -First 1
+            if ($asset) {
+                $to = Join-Path ([IO.Path]::GetTempPath()) ("lvmcp-" + [guid]::NewGuid().ToString('N'))
+                Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $to -Headers @{ 'User-Agent' = 'labview-mcp-release-check' }
+                Set-Variable -Name $helper.V -Value $to
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------------------------
+# 2. The tag itself, through the one script that owns the rule.
+# ---------------------------------------------------------------------------------------------
+
+if ($Tag) {
+    $tagScript = Join-Path $PSScriptRoot 'Assert-ReleaseTag.ps1'
+    if (Test-Path -LiteralPath $tagScript) {
+        & powershell -NoProfile -ExecutionPolicy Bypass -File $tagScript -Tag $Tag | Out-Null
+        if ($LASTEXITCODE -eq 0) { Ok "the tag '$Tag' is a valid vX.Y.Z" }
+        else {
+            # Single-quoted around the v* literal on purpose: in a double-quoted PowerShell string
+            # `v is the VERTICAL TAB escape, and the filter name silently vanished from this
+            # message the first time it fired.
+            Bad ("the tag '$Tag' is not a valid vX.Y.Z, so the release workflow's " + "'v*'" +
+                 ' tag filter never ran for it and its asset cannot have come from CI. Run ' +
+                 "scripts\Assert-ReleaseTag.ps1 -Tag $Tag for the diagnosis.")
+        }
+    } else { Skip 'the tag shape (Assert-ReleaseTag.ps1 is not beside this script)' }
+}
+
+# ---------------------------------------------------------------------------------------------
+# 3. Who uploaded it. This is the check that identified the incident, and it is the cheapest one.
+# ---------------------------------------------------------------------------------------------
+
+if ($Uploader) {
+    if ($Uploader -eq $CiUploader) { Ok "labview-mcp.zip was uploaded by $CiUploader" }
+    else {
+        Bad ("labview-mcp.zip was uploaded by '$Uploader', not $CiUploader - this release was cut " +
+             'BY HAND. Measured 2026-09-11: five such releases shipped a zip of bin\Debug\net8.0 ' +
+             'with no plugin manifest, a framework-dependent exe and a Python 3.14 pylabview ' +
+             'bundle. Delete the asset, and re-cut the release by pushing a vX.Y.Z tag.')
+    }
+}
+
+if (-not $archive) {
+    # Fall through to the report; there is nothing to open.
+    $skipArchive = $true
+}
+
+# ---------------------------------------------------------------------------------------------
+# 4. The archive itself.
+# ---------------------------------------------------------------------------------------------
+
+if ($archive) {
+    if ($Sha256Path -and (Test-Path -LiteralPath $Sha256Path)) {
+        $want = ([IO.File]::ReadAllText($Sha256Path, $Utf8) -split '\s+')[0].ToLowerInvariant()
+        $have = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($want -eq $have) { Ok 'the archive matches its published SHA-256' }
+        else { Bad "the archive's SHA-256 is $have but labview-mcp.sha256 says $want - the asset was replaced after it was hashed" }
+    } else { Skip "the archive's digest (no labview-mcp.sha256 to compare against)" }
+
+    $zip = [IO.Compression.ZipFile]::OpenRead($archive)
+    try {
+        $names = @($zip.Entries | ForEach-Object { $_.FullName })
+        $rootFiles = @($names | Where-Object { $_ -notmatch '/' })
+
+        # 4a. The plugin shape. Each of these is absent from a zipped build output, and each alone
+        #     makes the archive uninstallable.
+        foreach ($needed in @('.claude-plugin/plugin.json', '.mcp.json', 'VERSION.txt',
+                              'bin/LabVIEWMCP.exe',
+                              'bin/pylabview/python.exe',
+                              'bin/pylabview/app/pylabview/readRSRC.py')) {
+            if ($names -contains $needed) { Ok "the archive contains $needed" }
+            else { Bad "the archive has no '$needed'" }
+        }
+
+        if (@($names | Where-Object { $_ -like 'agents/*.md' }).Count -gt 0) { Ok 'the archive carries plugin-flavoured agents at agents/' }
+        else { Bad 'the archive has no agents/*.md - the plugin loader would register no agents' }
+
+        # 4b. The DIRECT signature of a zipped bin\Debug\net8.0: the exe and its dependencies loose
+        #     at the archive root. Checked positively rather than inferred from what is missing,
+        #     because this is the shape that actually shipped.
+        $looseBinaries = @($rootFiles | Where-Object { $_ -match '\.(dll|pdb|deps\.json|runtimeconfig\.json)$' -or $_ -eq 'LabVIEWMCP.exe' })
+        if ($looseBinaries.Count -eq 0) { Ok 'no loose binaries at the archive root' }
+        else {
+            # Parenthesised deliberately: `"a" + $array -join ', '` binds as
+            # `("a" + $array) -join ', '` in PowerShell and silently produces the wrong text.
+            $sample = (($looseBinaries | Select-Object -First 4) -join ', ')
+            Bad ("the archive root holds $($looseBinaries.Count) loose binary file(s) - e.g. $sample" +
+                 ". That is the shape of a zipped src\LabVIEWMCP\bin\Debug\net8.0: a " +
+                 'framework-dependent build output, not the self-contained single-file exe the ' +
+                 'workflow publishes at bin/LabVIEWMCP.exe. Never publish build.ps1 output.')
+        }
+
+        # 4c. VERSION.txt must name THIS release. A stale one means the archive is from another run.
+        $versionText = Get-EntryText $zip 'VERSION.txt'
+        if ($versionText) {
+            $fields = @{}
+            foreach ($line in ($versionText -split "`r?`n")) {
+                if ($line -match '^\s*([A-Za-z]+)\s*:\s*(.+?)\s*$') { $fields[$Matches[1]] = $Matches[2] }
+            }
+            if ($Tag) {
+                if ($fields['tag'] -eq $Tag) { Ok "VERSION.txt names the release tag ($Tag)" }
+                else { Bad "VERSION.txt says tag '$($fields['tag'])' but the release is '$Tag' - the archive is from a different run" }
+
+                $bare = $Tag -replace '^v', ''
+                if ($fields['version'] -eq $bare) { Ok "VERSION.txt version is $bare" }
+                else { Bad "VERSION.txt says version '$($fields['version'])', expected '$bare'" }
+            }
+            if ($fields['commit'] -match '^[0-9a-f]{40}$') { Ok "VERSION.txt records a commit ($($fields['commit'].Substring(0,8)))" }
+            else { Bad "VERSION.txt has no usable commit field (got '$($fields['commit'])')" }
+        }
+
+        # 4d. plugin.json's version, which is what `claude plugin list` shows.
+        $manifestText = Get-EntryText $zip '.claude-plugin/plugin.json'
+        if ($manifestText) {
+            $manifest = $manifestText | ConvertFrom-Json
+            $bare = if ($Tag) { $Tag -replace '^v', '' } else { $null }
+            if ($manifest.version -eq '0.0.0' -or -not $manifest.version) {
+                Bad ("plugin.json version is '$($manifest.version)' - the 0.0.0 placeholder was " +
+                     'never substituted, so `claude plugin list` cannot identify this install')
+            } elseif ($bare -and $manifest.version -ne $bare) {
+                Bad "plugin.json version is '$($manifest.version)' but the tag is '$Tag'"
+            } else { Ok "plugin.json version is $($manifest.version)" }
+        }
+
+        # 4e. The pylabview bundle's PROVENANCE. This is the check that explains the original
+        #     report: a hand-cut bundle came from a developer's own Python 3.14, which emits three
+        #     SyntaxWarnings from LVheap.py on every import, where CI's pinned 3.12 is silent. So
+        #     the Python tooling genuinely did behave differently - not because of the packaging,
+        #     but because of whose interpreter went in.
+        $bundleText = Get-EntryText $zip 'bin/pylabview/bundle.json'
+        if (-not $bundleText) {
+            Bad 'the archive has no bin/pylabview/bundle.json - the bundle carries no provenance'
+        } else {
+            $bundle = $bundleText | ConvertFrom-Json
+            if ($bundle.pythonVersion -eq '3.12') { Ok 'the pylabview bundle is the pinned Python 3.12' }
+            else {
+                Bad ("the pylabview bundle is Python '$($bundle.pythonVersion)', not the pinned " +
+                     '3.12. release.yml pins 3.12 because 3.14 emits three SyntaxWarnings from ' +
+                     "pylabview's own LVheap.py on every import, and those land in every pylv_* answer.")
+            }
+            if ($bundle.provisionedFrom -match '\\Users\\') {
+                Bad ("the pylabview bundle was provisioned from '$($bundle.provisionedFrom)' - a " +
+                     "USER PROFILE, so it came off somebody's workstation rather than from the " +
+                     'release workflow, which provisions it from the runner tool cache.')
+            } else { Ok "the pylabview bundle was provisioned from $($bundle.provisionedFrom)" }
+        }
+
+        # 4f. Completeness, against the manifest the workflow publishes. This is the check that
+        #     needs no second install, and it catches a MISSING file as well as an altered one.
+        if ($ManifestPath -and (Test-Path -LiteralPath $ManifestPath)) {
+            $want = Read-ManifestRows $ManifestPath
+            if ($want.Count -eq 0) {
+                Bad "$ManifestPath holds no '<sha256>  <path>' rows"
+            } else {
+                $have = Get-EntryHashes $zip
+                $onlyArchive = @($have.Keys  | Where-Object { -not $want.ContainsKey($_) })
+                $onlyManifest = @($want.Keys | Where-Object { -not $have.ContainsKey($_) })
+                $differing = @($have.Keys | Where-Object { $want.ContainsKey($_) -and $want[$_] -ne $have[$_] })
+                if ($onlyArchive.Count -eq 0 -and $onlyManifest.Count -eq 0 -and $differing.Count -eq 0) {
+                    Ok "all $($have.Count) archive entries match the published manifest"
+                } else {
+                    $sample = ((@($onlyArchive) + @($onlyManifest) + @($differing) |
+                                Select-Object -First 5) -join ', ')
+                    Bad ("the archive does not match its published manifest: " +
+                         "$($onlyArchive.Count) extra, $($onlyManifest.Count) missing, " +
+                         "$($differing.Count) altered. First few: $sample")
+                }
+            }
+        } else { Skip 'the per-file manifest comparison (no labview-mcp.manifest.sha256)' }
+    } finally { $zip.Dispose() }
+}
+
+if ($downloaded -and -not $KeepDownload) { Remove-Item -LiteralPath $downloaded -Force -ErrorAction SilentlyContinue }
+elseif ($downloaded) { Write-Host "kept: $downloaded" }
+
+# ---------------------------------------------------------------------------------------------
+# 5. The report.
+# ---------------------------------------------------------------------------------------------
+
+Write-Host ''
+foreach ($m in $passes) { Write-Host "  ok    $m" -ForegroundColor Green }
+foreach ($m in $skips)  { Write-Host "  skip  $m" -ForegroundColor DarkGray }
+Write-Host ''
+
+if ($failures.Count -eq 0) {
+    Write-Host "PUBLISHED RELEASE OK - $Tag is the workflow's own artefact." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host '=====================================================================' -ForegroundColor Red
+Write-Host " PUBLISHED RELEASE REJECTED - $Tag" -ForegroundColor Red
+Write-Host '=====================================================================' -ForegroundColor Red
+Write-Host ''
+foreach ($m in $failures) { Write-Host "  FAIL  $m" -ForegroundColor Red }
+Write-Host ''
+Write-Host '  Every plugin install resolves /releases/latest/download/labview-mcp.zip, so a bad' -ForegroundColor Red
+Write-Host '  asset on the newest release breaks installation for everyone until it is replaced.' -ForegroundColor Red
+Write-Host '  Cut releases ONLY by pushing a vX.Y.Z tag and letting the workflow publish.' -ForegroundColor Red
+Write-Host ''
+exit 1

--- a/tests/LabVIEWMCP.Tests/Cli/PublishedReleaseTests.cs
+++ b/tests/LabVIEWMCP.Tests/Cli/PublishedReleaseTests.cs
@@ -1,0 +1,354 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using LabVIEWMcp.Tests.Support;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Cli;
+
+/// <summary>
+/// scripts\Assert-PublishedRelease.ps1 - the guard against a release cut BY HAND.
+///
+/// WHY IT EXISTS. Measured 2026-09-11 over this repository's own release history: five releases -
+/// V1.1.5, V1.2.0, V1.2.2, V1.2.5, V1.2.8 - carry a `labview-mcp.zip` uploaded by a person rather
+/// than by github-actions[bot], at 19-21 MB against CI's 62 MB. V1.2.8's asset, downloaded and
+/// opened, is a zip of src\LabVIEWMCP\bin\Debug\net8.0: the exe and 46 loose DLLs at the archive
+/// root, no .claude-plugin/plugin.json, no .mcp.json, no agents/, and a pylabview bundle built
+/// from a developer's own Python 3.14 - the version release.yml pins away from because it emits
+/// three SyntaxWarnings from LVheap.py on every import. For four days
+/// /releases/latest/download/labview-mcp.zip, the URL the marketplace resolves, pointed at one.
+///
+/// THE FIXTURES ARE THE REAL SHAPES, not plausible ones. <see cref="Good"/> mirrors the v1.4.1
+/// archive (verified against the live release: 21 checks green, all 807 entries matching the
+/// published manifest) and <see cref="DebugOutput"/> mirrors the V1.2.8 archive file for file in
+/// kind. That distinction is the repository's own rule - "a tool tested against a plausible
+/// fixture is not tested" - and it matters here because the checks are about layout.
+///
+/// Each negative control changes exactly ONE thing about the good archive, so a passing test names
+/// the check that fired rather than merely that something did.
+/// </summary>
+public class PublishedReleaseTests : IDisposable
+{
+    private const string CiUploader = "github-actions[bot]";
+    private const string Commit = "f9143c9000000000000000000000000000000000";
+    private const string BundleFrom = @"C:\hostedtoolcache\windows\Python\3.12.10\x64";
+
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "lvmcp-relcheck-" + Guid.NewGuid().ToString("N"));
+
+    public PublishedReleaseTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* a temp dir is not worth failing a test over */ }
+    }
+
+    private static string ScriptPath()
+    {
+        var path = Res.FindRepoFile("scripts/Assert-PublishedRelease.ps1");
+        Assert.True(path is not null, "cannot find scripts/Assert-PublishedRelease.ps1");
+        return path!;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Fixtures
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A staging tree with the same shape as the published archive.</summary>
+    private string Good(string tag = "v1.4.1", Action<string>? mutate = null)
+    {
+        var dir = Path.Combine(_root, "good-" + Guid.NewGuid().ToString("N")[..8]);
+        var version = tag.TrimStart('v', 'V');
+
+        Write(dir, ".claude-plugin/plugin.json",
+            "{\n  \"name\": \"labview-mcp\",\n  \"version\": \"" + version + "\",\n"
+            + "  \"author\": { \"name\": \"Z\u00fchlke Engineering AG\" }\n}\n");
+        Write(dir, ".mcp.json",
+            "{\n  \"mcpServers\": { \"labview\": { \"command\": \"${CLAUDE_PLUGIN_ROOT}/bin/LabVIEWMCP.exe\" } }\n}\n");
+        Write(dir, "agents/labview-vi-generator.md", "---\nname: labview-vi-generator\n---\n");
+        Write(dir, "hooks/hooks.json", "{}\n");
+        Write(dir, "VERSION.txt",
+            $"tag: {tag}\nversion: {version}\ncommit: {Commit}\n"
+            + "built: 2026-09-11T21:13:00Z\nrun: https://example.invalid/runs/1\n");
+        Write(dir, "bin/LabVIEWMCP.exe", "not really an exe");
+        Write(dir, "bin/README.md", "# LabVIEW MCP\n");
+        Write(dir, "bin/pylabview/python.exe", "not really python");
+        Write(dir, "bin/pylabview/app/pylabview/readRSRC.py", "# readRSRC\n");
+        Write(dir, "bin/docs/connector-pane-patterns.tsv", "pattern\tterminals\n");
+        Write(dir, "bin/scripts/Assert-ReleaseTag.ps1", "# copied helper\n");
+        Write(dir, "bin/claude/CLAUDE.md", "# rules\n");
+        WriteBundleJson(dir, "3.12", BundleFrom);
+
+        mutate?.Invoke(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// A zipped src\LabVIEWMCP\bin\Debug\net8.0, in the same kind as the real V1.2.8 asset: the
+    /// apphost and its dependencies loose at the root, no plugin manifest anywhere, and the
+    /// pylabview bundle at pylabview\ rather than bin\pylabview\.
+    /// </summary>
+    private string DebugOutput()
+    {
+        var dir = Path.Combine(_root, "debugout-" + Guid.NewGuid().ToString("N")[..8]);
+
+        Write(dir, "LabVIEWMCP.exe", "apphost");
+        Write(dir, "LabVIEWMCP.dll", "managed");
+        Write(dir, "LabVIEWMCP.pdb", "symbols");
+        Write(dir, "LabVIEWMCP.deps.json", "{}");
+        Write(dir, "LabVIEWMCP.runtimeconfig.json", "{}");
+        Write(dir, "Google.Protobuf.dll", "dep");
+        Write(dir, "Grpc.Net.Client.dll", "dep");
+        Write(dir, "README.md", "# LabVIEW MCP\n");
+        Write(dir, "docs/aixml-reference.md", "# aixml\n");
+        Write(dir, "scripts/lvai_status.xml", "<xml/>\n");
+        Write(dir, "claude/CLAUDE.md", "# rules\n");
+        // Python 3.14, off a workstation - the real hand-cut bundle's own provenance.
+        WriteBundleJson(dir, "3.14", @"C:\Users\someone\AppData\Local\Programs\Python\Python314",
+                        relativeDir: "pylabview");
+        return dir;
+    }
+
+    private static void Write(string root, string relative, string content)
+    {
+        var path = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content, new UTF8Encoding(false));
+    }
+
+    /// <summary>
+    /// bundle.json WITH A BOM, because the real one has one - provision.ps1 writes it through
+    /// Out-File. That is not incidental: Windows PowerShell's ConvertFrom-Json rejects a leading
+    /// BOM with "Invalid JSON primitive: .", and the check script failed on its first run against
+    /// the live v1.4.1 archive for exactly that reason while passing every BOM-less fixture. The
+    /// BOM stays in the fixture so the reader's TrimStart cannot be dropped again.
+    /// </summary>
+    private static void WriteBundleJson(string root, string pythonVersion, string provisionedFrom,
+                                        string relativeDir = "bin/pylabview")
+    {
+        var json = "{\n    \"provisionedFrom\":  \"" + provisionedFrom.Replace(@"\", @"\\") + "\",\n"
+                 + "    \"provisionedUtc\":  \"2026-09-11 09:43:14Z\",\n"
+                 + "    \"pylabviewCommit\":  \"69768647c18d2d792a259b69884b2433761c3a4f\",\n"
+                 + "    \"pythonArch\":  \"x64\",\n"
+                 + "    \"pythonVersion\":  \"" + pythonVersion + "\"\n}\n";
+        var path = Path.Combine(root, relativeDir.Replace('/', Path.DirectorySeparatorChar), "bundle.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Running the script
+    // ---------------------------------------------------------------------------------------
+
+    private sealed record Archive(string ZipPath, string Sha256Path, string ManifestPath);
+
+    /// <summary>Zip a staging tree and produce the two sidecar files the workflow publishes.</summary>
+    private Archive Pack(string stagingDir, bool dropOneManifestEntry = false, bool corruptDigest = false)
+    {
+        var zipPath = Path.Combine(_root, Path.GetFileName(stagingDir) + ".zip");
+        ZipFile.CreateFromDirectory(stagingDir, zipPath, CompressionLevel.Fastest,
+                                    includeBaseDirectory: false);
+
+        var digest = corruptDigest ? new string('0', 64) : FileSha256(zipPath);
+        var shaPath = zipPath + ".sha256";
+        File.WriteAllText(shaPath, $"{digest}  labview-mcp.zip\n", new UTF8Encoding(false));
+
+        var rows = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(stagingDir, "*", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(stagingDir, file).Replace('\\', '/');
+            rows.Add($"{FileSha256(file)}  {rel}");
+        }
+        rows.Sort(StringComparer.Ordinal);
+        if (dropOneManifestEntry) rows.RemoveAt(rows.Count - 1);
+
+        var manifestPath = zipPath + ".manifest.sha256";
+        File.WriteAllText(manifestPath, string.Join("\n", rows) + "\n", new UTF8Encoding(false));
+
+        return new Archive(zipPath, shaPath, manifestPath);
+    }
+
+    private static string FileSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+    }
+
+    private static (int ExitCode, string Output) Run(params string[] args)
+    {
+        var psi = new ProcessStartInfo("powershell.exe")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-ExecutionPolicy");
+        psi.ArgumentList.Add("Bypass");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(ScriptPath());
+        foreach (var arg in args) psi.ArgumentList.Add(arg);
+
+        using var process = Process.Start(psi);
+        Assert.True(process is not null, "powershell.exe did not start");
+        var stdout = process!.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(180_000);
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    private (int ExitCode, string Output) Check(Archive archive, string tag = "v1.4.1",
+                                                string uploader = CiUploader)
+        => Run("-ZipPath", archive.ZipPath, "-Tag", tag, "-Uploader", uploader,
+               "-Sha256Path", archive.Sha256Path, "-ManifestPath", archive.ManifestPath);
+
+    // ---------------------------------------------------------------------------------------
+    // The positive control
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AWorkflowShapedArchivePasses()
+    {
+        var (exit, output) = Check(Pack(Good()));
+        Assert.True(exit == 0, $"the good archive was rejected:{Environment.NewLine}{output}");
+        Assert.Contains("PUBLISHED RELEASE OK", output, StringComparison.Ordinal);
+        // The manifest comparison must actually have RUN, not been skipped into a pass.
+        Assert.Contains("match the published manifest", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The BOM regression. bundle.json is the only file in the archive that carries one, and the
+    /// check crashed on it against the live release while every BOM-less fixture passed.
+    /// </summary>
+    [Fact]
+    public void ABomOnBundleJsonIsReadRatherThanCrashingTheCheck()
+    {
+        var staging = Good();
+        var bundle = Path.Combine(staging, "bin", "pylabview", "bundle.json");
+        Assert.Equal(0xEF, File.ReadAllBytes(bundle)[0]);   // the fixture really has a BOM
+
+        var (exit, output) = Check(Pack(staging));
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("Invalid JSON primitive", output, StringComparison.Ordinal);
+        Assert.Contains("pinned Python 3.12", output, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The failure this guard was built for
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AZippedDebugBuildOutputIsRejectedAndTheReasonsAreNamed()
+    {
+        var (exit, output) = Check(Pack(DebugOutput()), tag: "V1.2.8", uploader: "a-person");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("PUBLISHED RELEASE REJECTED", output, StringComparison.Ordinal);
+
+        foreach (var expected in new[]
+        {
+            "no '.claude-plugin/plugin.json'",     // not installable as a plugin
+            "no '.mcp.json'",                      // nothing launches the server
+            "no 'VERSION.txt'",                    // cannot identify itself
+            "no 'bin/LabVIEWMCP.exe'",             // .mcp.json's path does not resolve
+            "loose binary file(s)",                // the direct signature of bin\Debug\net8.0
+            "bin\\Debug\\net8.0",                  // and it says so by name
+            "uploaded by 'a-person'",              // cut by hand
+            "not a valid vX.Y.Z",                  // the upper-case tag that let it happen
+            "no agents/*.md",                      // the plugin loader would register none
+        })
+            Assert.Contains(expected, output, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // One-change negative controls
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AnUnsubstitutedVersionPlaceholderIsRejected()
+    {
+        var staging = Good(mutate: dir =>
+        {
+            var manifest = Path.Combine(dir, ".claude-plugin", "plugin.json");
+            File.WriteAllText(manifest,
+                File.ReadAllText(manifest).Replace("\"1.4.1\"", "\"0.0.0\""), new UTF8Encoding(false));
+        });
+
+        var (exit, output) = Check(Pack(staging));
+        Assert.Equal(1, exit);
+        Assert.Contains("placeholder was never substituted", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AVersionFileFromAnotherRunIsRejected()
+    {
+        var staging = Good(mutate: dir =>
+            Write(dir, "VERSION.txt",
+                $"tag: v1.3.0\nversion: 1.3.0\ncommit: {Commit}\nbuilt: 2026-09-11T09:43:14Z\n"));
+
+        var (exit, output) = Check(Pack(staging));
+        Assert.Equal(1, exit);
+        Assert.Contains("from a different run", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnUnpinnedPythonInTheBundleIsRejectedAndTheReasonGiven()
+    {
+        var staging = Good(mutate: dir => WriteBundleJson(dir, "3.14", BundleFrom));
+
+        var (exit, output) = Check(Pack(staging));
+        Assert.Equal(1, exit);
+        Assert.Contains("not the pinned", output, StringComparison.Ordinal);
+        // The WHY matters more than the verdict: this is the difference a user actually sees.
+        Assert.Contains("SyntaxWarnings", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ABundleProvisionedFromAWorkstationIsRejected()
+    {
+        var staging = Good(mutate: dir =>
+            WriteBundleJson(dir, "3.12", @"C:\Users\someone\AppData\Local\Programs\Python\Python312"));
+
+        var (exit, output) = Check(Pack(staging));
+        Assert.Equal(1, exit);
+        Assert.Contains("USER PROFILE", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnArchiveThatDoesNotMatchItsPublishedDigestIsRejected()
+    {
+        var (exit, output) = Check(Pack(Good(), corruptDigest: true));
+        Assert.Equal(1, exit);
+        Assert.Contains("replaced after it was hashed", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnArchiveThatDoesNotMatchItsPublishedManifestIsRejected()
+    {
+        var (exit, output) = Check(Pack(Good(), dropOneManifestEntry: true));
+        Assert.Equal(1, exit);
+        Assert.Contains("does not match its published manifest", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AHandUploadedAssetIsRejectedEvenWhenTheArchiveItselfIsPerfect()
+    {
+        // The whole point: an archive can be flawless and still not be the workflow's.
+        var (exit, output) = Check(Pack(Good()), uploader: "a-person");
+        Assert.Equal(1, exit);
+        Assert.Contains("cut BY HAND", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheOfflineModeSaysWhichChecksItCouldNotMake()
+    {
+        // A guard that silently skips is worse than one that fails: -ZipPath alone cannot see the
+        // asset set, the uploader, the digest or the manifest, and it must say so rather than
+        // report a clean bill of health.
+        var (exit, output) = Run("-ZipPath", Pack(Good()).ZipPath, "-Tag", "v1.4.1");
+        Assert.Equal(0, exit);
+        Assert.Contains("skip", output, StringComparison.Ordinal);
+        Assert.Contains("offline mode", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## TL;DR

The install discrepancy had a **second cause**, and it is not the packaging: **five releases were cut by hand.** `V1.1.5`, `V1.2.0`, `V1.2.2`, `V1.2.5` and `V1.2.8` each carry a `labview-mcp.zip` uploaded by a person rather than by `github-actions[bot]`, at 19–21 MB against CI's 62 MB — because the uppercase tag meant the workflow never ran.

`V1.2.8`'s asset, downloaded and opened, is **a zip of `src\LabVIEWMCP\bin\Debug\net8.0\`**. For four days `/releases/latest/download/labview-mcp.zip` — the URL the marketplace resolves for every plugin install — served it. That is what the README's "problem with the installer" banner was describing, and **the banner was not wrong.**

This PR adds the guard: `scripts/Assert-PublishedRelease.ps1`, run on every release event and **daily** by a new workflow, plus as a final step of `release.yml`. It also fixes a gap found in the same audit: `README.md` was staged next to the exe by the `.csproj` but not by `release.yml`.

## What the hand-cut archive actually was

| | hand-cut `V1.2.8` | the workflow's archive |
|---|---|---|
| `.claude-plugin/plugin.json` | **absent** → not installable as a plugin | at the root |
| `.mcp.json` | **absent** → nothing launches the server | at the root |
| plugin-flavoured `agents/`, `hooks/` | **absent** | at the root |
| the exe | at the **root**: a 151 kB apphost + **46 loose DLLs**, `.pdb`, `deps.json`, `runtimes/` — framework-dependent, so it does not start without the .NET 8 runtime | `bin/LabVIEWMCP.exe`, self-contained single file |
| pylabview bundle | at `pylabview/`, **Python 3.14**, `provisionedFrom: C:\Users\<person>\…\Python314`, provisioned 2026-08-25 and reused for every later hand-cut release | `bin/pylabview/`, pinned **3.12**, provisioned per release from the runner tool cache |
| `VERSION.txt` | absent | at the root |

`plugin/.mcp.json` launches `${CLAUDE_PLUGIN_ROOT}/bin/LabVIEWMCP.exe`, which that layout does not have.

**The Python 3.14 row answers the original report.** `release.yml` pins 3.12 with the comment *"3.14 also works — measured — but emits three SyntaxWarnings from pylabview's own LVheap.py on every import, and those are noise in every `pylv_*` answer."* So the Python tooling genuinely did behave differently between the two routes — not because the plugin route packaged less, but because a hand-cut release shipped a different interpreter.

## The guard

`scripts/Assert-PublishedRelease.ps1` downloads what is published and checks:

| check | what it catches |
|---|---|
| the asset is named `labview-mcp.zip` | `LabVIEWMCP_V0.8.5.zip` — a 404 for every plugin install |
| `labview-mcp.sha256`, `.manifest.sha256`, `labview-mcp-<tag>.zip` present | an asset set the workflow does not produce |
| the tag is a valid `vX.Y.Z` | the uppercase tag that left no CI asset to publish |
| **the uploader is `github-actions[bot]`** | a hand-cut release, whatever the archive looks like |
| digest matches the published `labview-mcp.sha256` | an asset replaced after it was hashed |
| `plugin.json`, `.mcp.json`, `VERSION.txt`, `bin/LabVIEWMCP.exe`, `bin/pylabview/python.exe`, `agents/*.md` present | the plugin shape |
| **no loose `*.dll`/`*.pdb`/`deps.json` and no `LabVIEWMCP.exe` at the archive root** | the direct signature of a zipped `bin\Debug\net8.0` |
| `VERSION.txt`'s `tag:`/`version:` match; 40-hex `commit:` | an archive from a different run |
| `plugin.json`'s `version` is the tag, not `0.0.0` | the placeholder never substituted |
| bundle is Python **3.12** and `provisionedFrom` not under `\Users\` | a bundle off somebody's workstation |
| every entry matches the published manifest | any missing, extra or altered file |

Wired in three places:

- **`.github/workflows/verify-release.yml`** — on every release event *and on a daily schedule*. The daily run is the point: an asset can be replaced on an existing release long after any workflow finished. Retried three times a minute apart, because a release event can fire while the 63 MB assets are still uploading.
- **`release.yml` step 12** — re-downloads what it just published and verifies it. Every step before that checks only the staging tree.
- **`build.ps1`** — its synopsis and its output now say its result is a development build that must never be published, listing the five ways it differs.

## Also: `README.md` was missing from the archive

The `.csproj` stages it next to the exe; `release.yml` did not. So a plugin install was the one route with no `README.md` — while `CLAUDE.md` asserted flatly that *"the build copies all of `docs\` and `README.md` next to the exe"*. Now staged as `bin/README.md`, and the claim corrected. **There are two lists of what ships** — the `.csproj` globs and the staging step — and anything named individually has to be in both.

## Verification — against the real artefacts, not fixtures

- **Live v1.4.1: 21 checks green**, including all 807 entries against its published manifest, the pinned Python 3.12, and `provisionedFrom C:\hostedtoolcache\windows\Python\3.12.10\x64`.
- **The real V1.2.8 asset: 11 failures**, each naming its cause — missing manifest, missing `.mcp.json`, missing `VERSION.txt`, 46 loose binaries at the root, `bin\Debug\net8.0` named explicitly, uploaded by a person, invalid tag, no agents.
- `PublishedReleaseTests` — 11 tests driving the script offline: a good fixture shaped from v1.4.1, a bad one shaped from V1.2.8, and one-change mutations for each individual check.
- Full suite **1678 passed, 0 failed**; `build.ps1` clean with all 12 embedded documents byte-identical; both workflow YAMLs parsed and all 20 embedded `pwsh` blocks syntax-checked with PowerShell's own parser.

## Two defects found by running against the real archive rather than trusting the fixtures

- **`bundle.json` carries a UTF-8 BOM** (provision.ps1 writes it through `Out-File`), and Windows PowerShell's `ConvertFrom-Json` rejects one with `Invalid JSON primitive: .`. It crashed on the first run against the live v1.4.1 while passing every BOM-less fixture — so the fixture now has a BOM and the reader strips it.
- **`"a" + $array -join ', '`** binds as `("a" + $array) -join ', '` in PowerShell and silently produced the wrong text in two failure messages.

## Note on the process

§1 of `docs/release-versioning.md` said "there is one build and one packaging path, so a difference can only be version skew" — true of the workflow, and silent about what was on the Releases page. Both installs behind that 732-file measurement happened to come from bot-uploaded tags, which was luck rather than method. **A pipeline guarantee is not a property of the artefact**; reading `uploader.login` off the API settled in one call what reasoning about the pipeline had hidden for four days. The section is corrected rather than deleted, with what it used to claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
