### PR TITLE
Make the pre-push gate test the tree being pushed

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -22,12 +22,119 @@ restarted. Prefer running this script over a bare `dotnet test` so the stop is d
 > need exclusive access to the TestStand COM engine; here the reason is the file lock on the
 > single build artifact. Same mechanism, different cause.
 
+## Which working tree it tests
+
+**It asks git, not itself.** The gate resolves the tree under test with
+`git rev-parse --show-toplevel`, and prints what it resolved:
+
+```
+  tree under test : C:\Users\...\labview-mcp\.claude\worktrees\my-branch
+  test project    : C:\Users\...\my-branch\tests\LabVIEWMCP.Tests\LabVIEWMCP.Tests.csproj
+  resolved by     : git rev-parse --show-toplevel
+  worktree        : linked (branch claude/my-branch)
+```
+
+Read those lines. They are the whole point of the paragraph below.
+
+### The worktree trap (measured 2026-09-11)
+
+The script used to derive the tree from its **own location**, `Split-Path -Parent $PSScriptRoot`.
+That is wrong in a linked worktree, and wrong in the worst possible direction.
+
+`core.hooksPath` is git **config**, and config is shared between a repository and every linked
+worktree — so each worktree inherits the main checkout's hooks directory. (In this repository the
+stored value is also *absolute*: `git config --show-origin --get core.hooksPath` reports
+`C:\...\labview-mcp\.githooks` from `.git/worktrees/<name>/config.worktree`, written by the
+worktree tooling. A relative `.githooks` would have resolved per-worktree and hidden the bug
+behind luck.) So pushing from `.claude/worktrees/<name>` ran the **main checkout's** script, and
+the gate tested whatever was checked out at `main`.
+
+Measured while pushing a branch from a worktree: the hook printed `Failed: 0, Passed: 1625` while
+the same script run by hand inside that worktree printed `1667`. The 42 missing tests were exactly
+the two files the pushed branch added. **A green gate for an unrelated tree is worse than no
+gate** — and the only tell was a test count nobody compares.
+
+What is authoritative instead: git runs a hook with the **pushed worktree** as the process working
+directory. Measured with a probe hook in a real linked worktree — cwd,
+`git rev-parse --show-toplevel` and `--git-dir` all named the worktree, and `GIT_DIR` was exported
+as `<main>/.git/worktrees/<name>`, which does not misdirect `--show-toplevel`.
+
+There is deliberately **no silent fallback** to the script's location while git is answering: a
+resolved tree with no test project is an error the gate stops on, because falling back to another
+tree is precisely the behaviour this replaced. The script-location route survives only for "git is
+not on `PATH` at all", and the output says so when it is used.
+
+Check the aim without running anything:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .githooks/run-tests.ps1 -ResolveOnly
+```
+
+`PrePushGateTests` builds a real `git worktree add` fixture with the absolute `core.hooksPath` and
+drives the real script through it, because a fixture that merely *looked* like a worktree passed
+against the broken script too.
+
+### The same trap, twice more
+
+Two other places asked "which tree am I in?" and got it wrong the same way. Both are fixed, and
+both are worth recognising, because the signal is always a **green** result about someone else's
+code:
+
+| Where | What it did | Why |
+|---|---|---|
+| `AixmlCheckTests.RepoRoot` | linted **main's** `scripts\` instead of the branch's | walked for a *directory* called `.git`; a worktree's `.git` is a **file**, so the walk went past it to the main checkout above |
+| `Directory.Build.targets` | re-ran its one-time hook setup on **every** worktree build, warning `MSB3371` three times | MSBuild's `Exists()` is true for a file, so `Exists('.git')` fired in a worktree where the marker can never be written |
+
+`tests/LabVIEWMCP.Tests/Support/RepoTree.cs` is now the single resolver for the test side: it
+matches on `CLAUDE.md` beside `scripts\` — repository content, which is the same in a worktree, a
+clone and a CI checkout — rather than on `.git`, whose *kind* of filesystem object depends on how
+the tree was created.
+
+## The .NET SDK preflight
+
+The gate checks for a usable SDK before building, and uses an SDK-bearing `dotnet` even when it is
+not the first one on `PATH`.
+
+**Measured 2026-09-11 on this station.** `C:\Program Files\dotnet` holds a runtime only —
+`dotnet.exe`, `host`, `shared`, and **no `sdk` directory** — while the SDK (8.0.424) is installed
+per-user at `C:\Users\<user>\.dotnet`. Program Files comes **first** on `PATH`, so a bare
+`dotnet build` / `dotnet test` dies with:
+
+```
+  * You intended to execute a .NET SDK command:
+      No .NET SDKs were found.
+```
+
+That aborted a push once, with a message about downloading .NET for what is purely **PATH order**.
+So the gate looks for a `dotnet` with an `sdk\` directory beside it — checking `DOTNET_ROOT`,
+`%USERPROFILE%\.dotnet`, and every `dotnet` on `PATH` — prepends that one for its own process, and
+says which it used:
+
+```
+  -> dotnet on PATH has no SDK; using C:\Users\<user>\.dotnet\dotnet.exe
+     (PATH had C:\Program Files\dotnet\dotnet.exe first - runtime only)
+```
+
+If no SDK is discoverable anywhere it prints the diagnosis and the two commands that confirm it
+(`Get-Command dotnet -All`, `dotnet --list-sdks`) instead of relaying the raw dump. To fix it for a
+whole shell rather than one hook run:
+
+```powershell
+$env:PATH = "$env:USERPROFILE\.dotnet;$env:PATH"
+```
+
 ## Activation (per clone)
 
 This is **automatic**: on the first `dotnet build` / `dotnet test`, `Directory.Build.targets`
 in the repo root runs `git config core.hooksPath .githooks` once per clone (tracked by a
 marker in `.git/`, which is never committed). Since you always build before pushing, the hook
 is active by the time it matters.
+
+That target deliberately does nothing in a **linked worktree**: `core.hooksPath` is shared
+config, so the main checkout's build has already set it for every worktree that will ever
+exist. A clone that is only ever built inside a worktree therefore needs the manual line
+below - though the worktree tooling in this repository sets `core.hooksPath` itself, so that
+gap is not reachable in practice.
 
 Set it manually only if you want the hook active *before* the first build, or if `git` was not
 on `PATH` during that build:
@@ -47,7 +154,7 @@ git config core.hooksPath   # -> .githooks
 | File | Role |
 |---|---|
 | `pre-push` | POSIX-sh entry point Git invokes; delegates to PowerShell |
-| `run-tests.ps1` | Checks for a `bin/`-locking server, runs `dotnet test`, returns the result |
+| `run-tests.ps1` | Resolves the tree under test **from git**, preflights the .NET SDK, stops a `bin/`-locking server, runs `dotnet test`, returns the result. `-ResolveOnly` prints the aim and exits without building. |
 
 The `pre-push` stub is forced to LF line endings via `.gitattributes`. Without that, `sh.exe`
 on Windows aborts with `bad interpreter: /bin/sh^M` and the hook silently never runs.

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -118,6 +118,24 @@ The general lesson, which is the repository's own: **a fix verified only by the 
 alongside it is not verified.** A plain `dotnet test` was green throughout; only a real
 `git push` from a worktree found either problem.
 
+**AND THE SAME LEAK REWROTE THE REPO'S IDENTITY, which is the symptom that actually reached a
+commit.** `core.bare` was the loud half; the quiet half is that the fixture also ran
+`git config user.email` / `user.name` / `commit.gpgsign`, so the real `.git/config` gained a
+`[user]` section reading `fixture <fixture@example.invalid>` and a `[commit] gpgsign = false` —
+**neither section existed before** — and the next two commits on the branch were authored by
+`fixture`. Nothing warns: `git commit` uses whatever identity resolves, and the repo-local value
+wins over the global one. **The repair is to UNSET the local keys, not to set a value**: the
+identity had always come from `~/.gitconfig`, so writing a guessed name would have pinned the repo
+to it for ever. `git config --unset user.name`, `--unset user.email`, `--unset commit.gpgsign`,
+then `git rebase <base> --exec "git commit --amend --no-edit --reset-author"` over the affected
+range. Check with `git config --show-origin --get user.name` — the *origin* is the answer, not the
+value.
+
+So one inherited `GIT_DIR` produced three distinct kinds of damage — a bare repo, a wrong author,
+and silently disabled commit signing — and only the first announced itself. **When a stray process
+has written to a repo's config, diff the whole file against what it should contain rather than
+fixing the symptom you noticed.**
+
 ## The .NET SDK preflight
 
 The gate checks for a usable SDK before building, and uses an SDK-bearing `dotnet` even when it is

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -90,6 +90,34 @@ matches on `CLAUDE.md` beside `scripts\` — repository content, which is the sa
 clone and a CI checkout — rather than on `.git`, whose *kind* of filesystem object depends on how
 the tree was created.
 
+### A hook inherits `GIT_*`, and a child git process obeys it
+
+Anything the gate runs inherits the variables git exported: `GIT_DIR` always, and during a push
+`GIT_INDEX_FILE`, `GIT_PREFIX` and `GIT_QUARANTINE_PATH` as well. A child `git` obeys those in
+preference to its own working directory — so a test that shells out to `git` is, by default,
+operating on **the repository being pushed**.
+
+**Measured 2026-09-11, and it damaged the repo.** `PrePushGateTests` builds its fixture with
+`git init` / `git add` / `git commit`. Run under a plain `dotnet test` all 1640 tests passed; run
+from inside the hook, 6 failed with exit 128 — and `git init` with an inherited `GIT_DIR` and no
+work tree **set `core.bare = true` on the real repository**, after which every work-tree operation
+answered `fatal: this operation must be run in a work tree`. Repaired with
+`git config core.bare false`; `git fsck` was clean.
+
+Two things came out of it, and both are now in place:
+
+- The tests strip every `GIT_*` variable from their child processes (`PrePushGateTests.Run`). Any
+  future test that invokes `git` must do the same.
+- The gate no longer *guesses* when git cannot name the work tree. That broken state was what
+  revealed it: the first fixed script fell back to its own location, tested the main checkout and
+  printed **PASS** for a worktree's push — the original defect returning through the escape hatch.
+  `GIT_DIR` being set is how the script knows it is a hook, and as a hook git's answer is
+  mandatory.
+
+The general lesson, which is the repository's own: **a fix verified only by the test written
+alongside it is not verified.** A plain `dotnet test` was green throughout; only a real
+`git push` from a worktree found either problem.
+
 ## The .NET SDK preflight
 
 The gate checks for a usable SDK before building, and uses an SDK-bearing `dotnet` even when it is

--- a/.githooks/run-tests.ps1
+++ b/.githooks/run-tests.ps1
@@ -1,12 +1,16 @@
 # ============================================================================
 #  LabVIEW MCP — pre-push test gate (invoked by .githooks/pre-push)
 #  ---------------------------------------------------------------------------
-#  1. Stops any running MCP server. It has to: there is one configuration
+#  0. Resolves WHICH working tree to test — from git, not from this script's own
+#     location. See "the worktree trap" below; getting this wrong made the gate
+#     report PASS for a tree nobody was pushing.
+#  1. Makes sure the `dotnet` on PATH actually has an SDK. See "the SDK trap".
+#  2. Stops any running MCP server. It has to: there is one configuration
 #     (Debug) and one artifact, and `dotnet test` rebuilds the main project as a
 #     dependency — into the very file the running server holds open. Without the
 #     stop the build fails with MSB3027, but only when the sources actually
 #     changed, which makes it an intermittent mystery rather than an error.
-#  2. Runs the test suite.
+#  3. Runs the test suite.
 #  Exits 0 only when ALL tests pass — any other exit code blocks the push.
 #
 #  Stopping is safe: no state lives in the process. But note the Claude client
@@ -14,7 +18,58 @@
 #  stay gone until the client is restarted. That is the cost of having a single
 #  configuration; the alternative was a second build flavour nobody could keep
 #  straight.
+#
+#  ---------------------------------------------------------------------------
+#  THE WORKTREE TRAP (measured 2026-09-11, and it made this gate WORSE THAN NONE)
+#  ---------------------------------------------------------------------------
+#  This script used to derive the tree under test from its OWN location:
+#
+#      $repoRoot = Split-Path -Parent $PSScriptRoot      # WRONG
+#
+#  `core.hooksPath` is git *config*, and config is shared between a repository
+#  and every linked worktree — so each worktree inherits the MAIN checkout's
+#  hooks directory. (Worse, the value stored in this repo's per-worktree config
+#  is ABSOLUTE: `C:\...\labview-mcp\.githooks`. A relative `.githooks` would
+#  have resolved per-worktree and hidden the bug behind luck.) So when pushing
+#  from `.claude/worktrees/<name>`, $PSScriptRoot was the MAIN checkout's
+#  `.githooks`, and the gate tested whatever was checked out at main.
+#
+#  Measured: pushing a branch from a worktree, the hook printed
+#  `Failed: 0, Passed: 1625` while the same script run by hand inside that
+#  worktree printed `Failed: 0, Passed: 1667`. The 42 missing tests were exactly
+#  the two files the pushed branch added. A green gate, for an unrelated tree.
+#
+#  What is authoritative instead: git runs a hook with the PUSHED worktree as the
+#  process working directory. Measured with a probe hook in a real linked
+#  worktree — cwd, `git rev-parse --show-toplevel` and `--git-dir` all named the
+#  worktree, and `GIT_DIR` was exported as `<main>/.git/worktrees/<name>`, which
+#  does not misdirect `--show-toplevel`. So ASK GIT.
+#
+#  There is deliberately NO silent fallback to $PSScriptRoot when git answers: a
+#  git answer that does not contain the test project is an error worth stopping
+#  on, because falling back is precisely the wrong-tree behaviour this replaced.
+#  The script-location route survives only for "git is not available at all".
+#
+#  ---------------------------------------------------------------------------
+#  THE SDK TRAP (measured 2026-09-11 on this station)
+#  ---------------------------------------------------------------------------
+#  `C:\Program Files\dotnet` holds a RUNTIME only — `dotnet.exe`, `host`,
+#  `shared`, and no `sdk` directory — while the SDK (8.0.424) is installed
+#  per-user at `C:\Users\<user>\.dotnet`. Program Files comes FIRST on PATH, so a
+#  bare `dotnet build` / `dotnet test` dies with "No .NET SDKs were found" and a
+#  link to the download page. Inside the hook that aborts the push with a message
+#  about installing .NET, which is not what went wrong. So preflight the SDK, and
+#  where an SDK-bearing `dotnet` is discoverable elsewhere, use THAT one and say
+#  so rather than failing with advice.
 # ============================================================================
+
+param(
+    # Resolve the tree under test, print it, and exit 0 — without stopping any
+    # server and without running the suite. Two uses: a human can check what the
+    # gate is aimed at, and PrePushGateTests drives it against a real linked
+    # worktree, which is the only way to prove the trap above stays fixed.
+    [switch]$ResolveOnly
+)
 
 # Let $LASTEXITCODE — not an exception — carry dotnet's result, even under
 # PowerShell 7's native-command error handling.
@@ -23,21 +78,141 @@ if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction Sile
     $PSNativeCommandUseErrorActionPreference = $false
 }
 
-# Repo root = parent of the .githooks directory this script lives in.
-$repoRoot = Split-Path -Parent $PSScriptRoot
-$testProj = Join-Path $repoRoot 'tests\LabVIEWMCP.Tests\LabVIEWMCP.Tests.csproj'
+$TestProjectRelativePath = 'tests\LabVIEWMCP.Tests\LabVIEWMCP.Tests.csproj'
 
 Write-Host ''
 Write-Host '================================================================' -ForegroundColor Cyan
 Write-Host '  pre-push gate: LabVIEW MCP tests' -ForegroundColor Cyan
 Write-Host '================================================================' -ForegroundColor Cyan
 
+# -- 0) resolve WHICH tree to test ------------------------------------------
+# Normalise git's forward slashes to a native path so the printed line matches
+# what every other tool in this repo shows.
+function Convert-ToNativePath([string]$path) {
+    if ([string]::IsNullOrWhiteSpace($path)) { return $null }
+    try { return [IO.Path]::GetFullPath($path.Trim()) } catch { return $path.Trim() }
+}
+
+$treeFromGit = $null
+$gitAvailable = $false
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    $gitAvailable = $true
+    $topLevel = & git rev-parse --show-toplevel 2>$null
+    if ($LASTEXITCODE -eq 0 -and $topLevel) {
+        $treeFromGit = Convert-ToNativePath (@($topLevel)[0])
+    }
+}
+
+if ($treeFromGit) {
+    $repoRoot = $treeFromGit
+    $resolvedBy = 'git rev-parse --show-toplevel'
+} else {
+    # Only reachable with no git on PATH, or outside a repository (a bare
+    # `powershell -File .githooks\run-tests.ps1` in an exported tree). Then this
+    # script's location is the best evidence there is.
+    $repoRoot = Convert-ToNativePath (Split-Path -Parent $PSScriptRoot)
+    $resolvedBy = if ($gitAvailable) { 'script location (not inside a git work tree)' }
+                  else               { 'script location (git not on PATH)' }
+}
+
+$testProj = Join-Path $repoRoot $TestProjectRelativePath
+
+# Print the aim BEFORE doing anything, so a wrong tree is visible in the output
+# instead of inferable only from a test count.
+Write-Host ("  tree under test : {0}" -f $repoRoot)
+Write-Host ("  test project    : {0}" -f $testProj)
+Write-Host ("  resolved by     : {0}" -f $resolvedBy) -ForegroundColor DarkGray
+
+# Name a linked worktree explicitly. This is the case that used to be silently
+# wrong, so it is the case worth being loud about.
+if ($gitAvailable -and $treeFromGit) {
+    $commonDir = & git rev-parse --git-common-dir 2>$null
+    $gitDir    = & git rev-parse --git-dir 2>$null
+    if ($commonDir -and $gitDir -and
+        (Convert-ToNativePath (@($commonDir)[0])) -ne (Convert-ToNativePath (@($gitDir)[0]))) {
+        $branch = & git rev-parse --abbrev-ref HEAD 2>$null
+        Write-Host ("  worktree        : linked (branch {0})" -f (@($branch)[0])) -ForegroundColor DarkGray
+    }
+}
+
 if (-not (Test-Path $testProj)) {
+    Write-Host ''
     Write-Host "  ERROR: test project not found at $testProj" -ForegroundColor Red
+    if ($treeFromGit) {
+        Write-Host '         git named that work tree, so this is not the worktree trap -' -ForegroundColor DarkGray
+        Write-Host '         the pushed tree genuinely has no test project. Refusing to test' -ForegroundColor DarkGray
+        Write-Host '         some other tree instead, which is what this gate used to do.' -ForegroundColor DarkGray
+    }
     exit 1
 }
 
-# -- 1) free the build output ------------------------------------------------
+if ($ResolveOnly) {
+    Write-Host ''
+    Write-Host '  -ResolveOnly: stopping here without building or testing.' -ForegroundColor DarkGray
+    exit 0
+}
+
+# -- 1) make sure `dotnet` has an SDK ---------------------------------------
+# Returns the path of a `dotnet` that can actually run SDK commands, or $null.
+function Find-DotnetWithSdk {
+    $candidates = [System.Collections.Generic.List[string]]::new()
+
+    $onPath = Get-Command dotnet -ErrorAction SilentlyContinue
+    if ($onPath) { $candidates.Add($onPath.Source) }
+
+    # The usual homes for an SDK the PATH order hides: an explicit DOTNET_ROOT, the
+    # per-user install, and any other `dotnet` further down PATH.
+    if ($env:DOTNET_ROOT) { $candidates.Add((Join-Path $env:DOTNET_ROOT 'dotnet.exe')) }
+    if ($env:USERPROFILE) { $candidates.Add((Join-Path $env:USERPROFILE '.dotnet\dotnet.exe')) }
+    if ($HOME)            { $candidates.Add((Join-Path $HOME '.dotnet\dotnet.exe')) }
+    Get-Command dotnet -All -ErrorAction SilentlyContinue |
+        ForEach-Object { $candidates.Add($_.Source) }
+
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if (-not (Test-Path $candidate)) { continue }
+        # An SDK directory beside the host is the cheap test, and it is the exact
+        # thing missing from the runtime-only install: no process launch needed.
+        $sdkDir = Join-Path (Split-Path -Parent $candidate) 'sdk'
+        if (-not (Test-Path $sdkDir)) { continue }
+        if (@(Get-ChildItem $sdkDir -Directory -ErrorAction SilentlyContinue).Count -gt 0) {
+            return (Convert-ToNativePath $candidate)
+        }
+    }
+    return $null
+}
+
+$dotnet = Find-DotnetWithSdk
+if (-not $dotnet) {
+    Write-Host ''
+    Write-Host '  ERROR: no .NET SDK found - cannot run the tests.' -ForegroundColor Red
+    Write-Host ''
+    Write-Host '  This is usually PATH ORDER, not a missing install. A runtime-only' -ForegroundColor DarkGray
+    Write-Host '  "C:\Program Files\dotnet" (dotnet.exe + shared, NO sdk directory) ahead of a' -ForegroundColor DarkGray
+    Write-Host '  per-user SDK in "%USERPROFILE%\.dotnet" gives exactly this, and dotnet reports' -ForegroundColor DarkGray
+    Write-Host '  it as "No .NET SDKs were found" with a download link.' -ForegroundColor DarkGray
+    Write-Host ''
+    Write-Host '  Check which hosts you have, and whether each has an sdk directory:' -ForegroundColor DarkGray
+    Write-Host '      Get-Command dotnet -All | ForEach-Object { $_.Source }' -ForegroundColor DarkGray
+    Write-Host '      dotnet --list-sdks' -ForegroundColor DarkGray
+    Write-Host ''
+    Write-Host '  If one of them does, put it first for this shell:' -ForegroundColor DarkGray
+    Write-Host '      $env:PATH = "$env:USERPROFILE\.dotnet;$env:PATH"' -ForegroundColor DarkGray
+    Write-Host '  Otherwise install an SDK: https://aka.ms/dotnet/download' -ForegroundColor DarkGray
+    exit 1
+}
+
+$dotnetDir = Split-Path -Parent $dotnet
+$firstOnPath = (Get-Command dotnet -ErrorAction SilentlyContinue).Source
+if ($firstOnPath -and (Convert-ToNativePath $firstOnPath) -ne $dotnet) {
+    # The first `dotnet` on PATH has no SDK. Put the one that does in front for
+    # this process, so MSBuild's own child `dotnet` calls agree with ours.
+    Write-Host ("  -> dotnet on PATH has no SDK; using {0}" -f $dotnet) -ForegroundColor Yellow
+    Write-Host ("     (PATH had {0} first - runtime only)" -f $firstOnPath) -ForegroundColor DarkGray
+    $env:PATH = "$dotnetDir;$env:PATH"
+}
+
+# -- 2) free the build output ------------------------------------------------
 $running = @(Get-Process -Name 'LabVIEWMCP' -ErrorAction SilentlyContinue)
 if ($running.Count -gt 0) {
     Write-Host ("  -> stopping {0} MCP server process(es) - they lock the build output" -f $running.Count) -ForegroundColor Yellow
@@ -48,18 +223,26 @@ if ($running.Count -gt 0) {
     Write-Host '     (restart the Claude client afterwards to get the lvai_* tools back)' -ForegroundColor DarkGray
 }
 
-# -- 2) run the tests -------------------------------------------------------
+# -- 3) run the tests -------------------------------------------------------
 Write-Host '  -> dotnet test (Debug / net8.0) ...' -ForegroundColor Yellow
 Write-Host ''
 
-& dotnet test $testProj --configuration Debug --nologo
-$code = $LASTEXITCODE
+# Run from the tree under test, so anything resolved relative to the working
+# directory (a nuget.config, a Directory.Build.* probe) belongs to that tree too.
+Push-Location $repoRoot
+try {
+    & $dotnet test $testProj --configuration Debug --nologo
+    $code = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
 
 Write-Host ''
 if ($code -eq 0) {
-    Write-Host '  PASS: all tests green - push continues.' -ForegroundColor Green
+    Write-Host ("  PASS: all tests green in {0} - push continues." -f $repoRoot) -ForegroundColor Green
 } else {
     Write-Host ("  FAIL: tests did not pass (exit {0}) - push aborted." -f $code) -ForegroundColor Red
+    Write-Host ("        Tree tested: {0}" -f $repoRoot) -ForegroundColor DarkGray
     Write-Host '        Fix the tests, or bypass in an emergency: git push --no-verify' -ForegroundColor DarkGray
 }
 

--- a/.githooks/run-tests.ps1
+++ b/.githooks/run-tests.ps1
@@ -103,16 +103,38 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
     }
 }
 
+# Git EXPORTS GIT_DIR to a hook - measured with a probe hook in a linked worktree, where it
+# was `<main>/.git/worktrees/<name>`. So its presence is how this script knows it is running
+# as a hook rather than by hand, and that distinction decides whether a fallback is allowed.
+$invokedAsHook = -not [string]::IsNullOrEmpty($env:GIT_DIR)
+
 if ($treeFromGit) {
     $repoRoot = $treeFromGit
     $resolvedBy = 'git rev-parse --show-toplevel'
+} elseif ($invokedAsHook) {
+    # A GATE THAT CANNOT ESTABLISH WHAT IT IS TESTING MUST NOT SAY PASS.
+    #
+    # Found the hard way, 2026-09-11: with `core.bare` accidentally set to true on the shared
+    # config, `rev-parse --show-toplevel` answered "fatal: this operation must be run in a work
+    # tree" - and an earlier version of this script fell back to its own location, tested the
+    # MAIN checkout and printed PASS for a worktree's push. That is the exact defect this file
+    # exists to prevent, walking back in through the fallback. So when git is driving us and
+    # git cannot name the work tree, stop.
+    Write-Host ''
+    Write-Host '  ERROR: git could not name the work tree being pushed.' -ForegroundColor Red
+    Write-Host '         Refusing to guess: this gate must not report PASS for a tree it only' -ForegroundColor DarkGray
+    Write-Host '         assumed. Check the repository state - `git status` here, and' -ForegroundColor DarkGray
+    Write-Host '         `git config --show-origin --get core.bare` (it must be false for a' -ForegroundColor DarkGray
+    Write-Host '         normal checkout; true makes every work-tree operation fail).' -ForegroundColor DarkGray
+    Write-Host '         Then push again, or bypass in an emergency: git push --no-verify' -ForegroundColor DarkGray
+    exit 1
 } else {
-    # Only reachable with no git on PATH, or outside a repository (a bare
-    # `powershell -File .githooks\run-tests.ps1` in an exported tree). Then this
-    # script's location is the best evidence there is.
+    # Run by hand outside a repository - an exported tree, a zip, a CI checkout with no git
+    # metadata. No push is in flight, so the script's own location is the best evidence there
+    # is, and the header says plainly that it was used.
     $repoRoot = Convert-ToNativePath (Split-Path -Parent $PSScriptRoot)
-    $resolvedBy = if ($gitAvailable) { 'script location (not inside a git work tree)' }
-                  else               { 'script location (git not on PATH)' }
+    $resolvedBy = if ($gitAvailable) { 'script location - NOT inside a git work tree' }
+                  else               { 'script location - git not on PATH' }
 }
 
 $testProj = Join-Path $repoRoot $TestProjectRelativePath

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1504,6 +1504,50 @@ Use the second one rather than a bare `dotnet test`: a running MCP server holds 
 exe, and the script stops it first. After either command the `lvai_*` tools are gone from the
 current session until the client is restarted — nothing is lost, but plan the restart.
 
+**THE PRE-PUSH GATE USED TO TEST THE WRONG TREE FROM A WORKTREE, and reported PASS for it.**
+Measured 2026-09-11. `run-tests.ps1` derived the tree under test from its own location, and
+`core.hooksPath` is git *config* — shared between a repository and every linked worktree, and stored
+here as an ABSOLUTE path in `.git/worktrees/<name>/config.worktree`. So a push from
+`.claude/worktrees/<name>` ran the MAIN checkout's script and tested whatever was at `main`: the hook
+printed `Passed: 1625` where the worktree's own run printed `1667`, the 42 difference being exactly
+the branch's two new test files. **A green gate for an unrelated tree is worse than no gate**, and the
+only tell was a count nobody compares. It now resolves with `git rev-parse --show-toplevel` — git runs
+a hook with the pushed worktree as its working directory, measured with a probe hook — prints the tree
+and the test project it resolved, and `-ResolveOnly` shows the aim without building.
+
+**The same question was asked wrong in two more places, both fixed, and the signal was always a GREEN
+result about someone else's code.** `AixmlCheckTests.RepoRoot` walked for a *directory* called `.git`
+— a linked worktree's `.git` is a **FILE**, so the walk went past it and linted `main`'s `scripts\`;
+`Directory.Build.targets` guarded on `Exists('.git')`, which MSBuild satisfies with that same file, so
+its one-time hook setup re-ran on every worktree build and emitted three `MSB3371` warnings per build
+for a marker it could never write. **Never identify this repository by `.git`** — its *kind* of
+filesystem object depends on how the tree was created. `tests/.../Support/RepoTree.cs` is the one
+resolver now, matching `CLAUDE.md` beside `scripts\`.
+
+**AND A HOOK'S CHILDREN INHERIT `GIT_*`, WHICH IS HOW THE GATE'S OWN TESTS SET `core.bare = true` ON
+THE REAL REPO.** Git exports `GIT_DIR` to every hook, plus `GIT_INDEX_FILE`, `GIT_PREFIX` and
+`GIT_QUARANTINE_PATH` during a push, and a child `git` obeys them over its own working directory —
+so `PrePushGateTests`' fixture-building `git init` ran against the repository being pushed, and with
+`GIT_DIR` set and no work tree `git init` marks it **bare**. Every later work-tree operation then
+answered `fatal: this operation must be run in a work tree`. Repaired with `git config core.bare
+false`, `git fsck` clean. **Any test that shells out to `git` must strip `GIT_*` first.** The gate
+also stops rather than guessing now: while that config was broken, the *fixed* script fell back to
+its own location, tested `main` and printed PASS — the original defect returning through its own
+escape hatch.
+
+**A PLAIN `dotnet test` WAS GREEN THROUGH ALL OF THAT.** 1640 passing locally, 6 failing inside the
+hook, and the two config-corruption rounds invisible either way. Only a real `git push` from a
+worktree found any of it — the same rule this file states for LabVIEW tools, applied to our own
+tooling: **a fix verified only by the test written alongside it is not verified.**
+
+**AND `dotnet` ON THIS STATION NEEDS ITS PATH CHECKED BEFORE BLAMING ANYTHING ELSE.**
+`C:\Program Files\dotnet` holds a RUNTIME with no `sdk` directory and comes FIRST on `PATH`, while the
+SDK (8.0.424) is per-user in `%USERPROFILE%\.dotnet`. A bare `dotnet build` / `dotnet test` therefore
+dies with `No .NET SDKs were found` and a download link — for what is purely PATH order, and it
+aborted a push that way. The gate now finds a `dotnet` with an `sdk\` directory beside it, uses that
+one and says which; for a shell of your own, `$env:PATH = "$env:USERPROFILE\.dotnet;$env:PATH"`.
+`.githooks/README.md` has every measurement above.
+
 **NEVER RUN `dotnet msbuild -t:Compile` HERE, and do not build to a redirected output path either.**
 Both look like harmless ways to type-check around that exe lock, and both silently produce a DLL
 **with no embedded resources** — then mark it up to date, so the next full `build.ps1` inherits it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1535,6 +1535,24 @@ also stops rather than guessing now: while that config was broken, the *fixed* s
 its own location, tested `main` and printed PASS — the original defect returning through its own
 escape hatch.
 
+**AND THE SAME LEAK REWROTE THE REPO'S IDENTITY, which is the symptom that actually reached a
+commit.** `core.bare` was the loud half; the quiet half is that the fixture also ran
+`git config user.email` / `user.name` / `commit.gpgsign`, so the real `.git/config` gained a
+`[user]` section reading `fixture <fixture@example.invalid>` and a `[commit] gpgsign = false` —
+**neither section existed before** — and the next two commits on the branch were authored by
+`fixture`. Nothing warns: `git commit` uses whatever identity resolves, and the repo-local value
+wins over the global one. **The repair is to UNSET the local keys, not to set a value**: the
+identity had always come from `~/.gitconfig`, so writing a guessed name would have pinned the repo
+to it for ever. `git config --unset user.name`, `--unset user.email`, `--unset commit.gpgsign`,
+then `git rebase <base> --exec "git commit --amend --no-edit --reset-author"` over the affected
+range. Check with `git config --show-origin --get user.name` — the *origin* is the answer, not the
+value.
+
+So one inherited `GIT_DIR` produced three distinct kinds of damage — a bare repo, a wrong author,
+and silently disabled commit signing — and only the first announced itself. **When a stray process
+has written to a repo's config, diff the whole file against what it should contain rather than
+fixing the symptom you noticed.**
+
 **A PLAIN `dotnet test` WAS GREEN THROUGH ALL OF THAT.** 1640 passing locally, 6 failing inside the
 hook, and the two config-corruption rounds invisible either way. Only a real `git push` from a
 worktree found any of it — the same rule this file states for LabVIEW tools, applied to our own

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,10 +11,44 @@
        Runs exactly once per clone: the marker lives in .git/ (never tracked), so
        every fresh clone re-runs it, while an already-configured clone skips it.
        Everything is ContinueOnError so a git-less or non-clone build never breaks.
+
+       ============================================================================
+       WHY THE CONDITION TESTS `.git\config` AND NOT `.git` (measured 2026-09-11)
+
+       In a LINKED WORKTREE, `.git` is a FILE holding a `gitdir:` pointer, not a
+       directory. MSBuild's Exists() is true for a file, so the old condition
+       `Exists('$(MSBuildThisFileDirectory).git')` fired in every worktree — and
+       then the Touch could not create `<worktree>\.git\hooks-configured`, because
+       `.git` is not a directory to put a file in. So the marker was never stamped,
+       the target re-ran on EVERY build, and each build emitted three copies of
+
+           warning MSB3371: The file "...\.git\hooks-configured" cannot be created.
+
+       `.git\config` exists only where `.git` is a real directory, so it separates a
+       normal checkout from a linked worktree exactly, with no extra process launch.
+
+       SKIPPING IN A WORKTREE IS ALSO THE CORRECT BEHAVIOUR, not merely the quiet
+       one. `core.hooksPath` is *config*, and config is shared between a repository
+       and all of its linked worktrees — so the main checkout's build has already
+       set it for every worktree that will ever exist, and a worktree re-running it
+       can only write a value that is then shadowed: measured here, the stored value
+       comes from `.git/worktrees/<name>/config.worktree` (written with an ABSOLUTE
+       path by the worktree tooling), which takes precedence over the relative one
+       this target writes into `.git/config`.
+
+       That absolute value is why `.githooks\run-tests.ps1` must resolve the tree
+       under test from git rather than from its own location — see "the worktree
+       trap" in that file. The value written HERE is relative and always has been;
+       it is not the source of the absolute one.
+
+       A clone that only ever builds inside a worktree therefore never gets its
+       hooks configured by this target. That is the documented manual one-liner in
+       .githooks/README.md, and the worktree tooling in this repository sets
+       core.hooksPath itself, so the gap is not reachable in practice.
        ============================================================================ -->
   <Target Name="ConfigureGitHooks"
           BeforeTargets="Build"
-          Condition="Exists('$(MSBuildThisFileDirectory).git') And !Exists('$(MSBuildThisFileDirectory).git\hooks-configured')">
+          Condition="Exists('$(MSBuildThisFileDirectory).git\config') And !Exists('$(MSBuildThisFileDirectory).git\hooks-configured')">
 
     <Message Importance="high"
              Text="[git hooks] Setting core.hooksPath -> .githooks (one-time for this clone)" />

--- a/tests/LabVIEWMCP.Tests/Infra/AixmlCheckTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/AixmlCheckTests.cs
@@ -1,4 +1,5 @@
 ﻿using LabVIEWMcp.Infra;
+using LabVIEWMcp.Tests.Support;
 using Xunit;
 
 namespace LabVIEWMcp.Tests.Infra;
@@ -535,13 +536,9 @@ public sealed class ShippedHelperAixmlTests
         }
     }
 
-    private static string RepoRoot(string leaf)
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir is not null && !Directory.Exists(Path.Combine(dir, ".git")))
-            dir = Path.GetDirectoryName(dir);
-        return Path.Combine(dir ?? ".", leaf);
-    }
+    // Was a walk for a directory called ".git", which in a linked worktree lands on the MAIN
+    // checkout and lints ITS scripts\ instead of the branch's. RepoTree explains the measurement.
+    private static string RepoRoot(string leaf) => RepoTree.Path(leaf);
 
     [Theory]
     [MemberData(nameof(Helpers))]

--- a/tests/LabVIEWMCP.Tests/Infra/PrePushGateTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/PrePushGateTests.cs
@@ -1,0 +1,405 @@
+using System.Diagnostics;
+using LabVIEWMcp.Tests.Support;
+using Xunit;
+
+namespace LabVIEWMcp.Tests.Infra;
+
+/// <summary>
+/// The pre-push gate must test THE TREE BEING PUSHED.
+///
+/// THE DEFECT THESE EXIST FOR, measured 2026-09-11. <c>run-tests.ps1</c> derived the tree under
+/// test from its own location (<c>Split-Path -Parent $PSScriptRoot</c>). But <c>core.hooksPath</c>
+/// is git config, and config is shared between a repository and every linked worktree - so a push
+/// from <c>.claude\worktrees\&lt;name&gt;</c> ran the MAIN checkout's hook script, and the gate
+/// tested whatever was checked out at main. It printed <c>Failed: 0, Passed: 1625</c> while the same
+/// script run by hand inside the worktree printed <c>1667</c>; the 42 missing tests were exactly the
+/// two files the pushed branch added. A green gate for an unrelated tree is worse than no gate.
+///
+/// WHY THE TESTS BUILD A REAL WORKTREE. A fixture that merely looked like one would have passed
+/// against the broken script too: the whole defect lives in how git and the filesystem disagree
+/// about what <c>.git</c> is, and in which directory git hands a hook. Nothing short of
+/// <c>git worktree add</c>, plus the absolute <c>core.hooksPath</c> this repo's worktrees really
+/// carry, reproduces it. This is the repository's own rule that a tool tested against a plausible
+/// fixture is not tested - and the reason the fixture below is a throwaway git repo rather than a
+/// tree of empty directories.
+///
+/// The fixtures contain a STUB csproj, never built: these tests check the gate's AIM, and an aim is
+/// settled by which project path it resolves, which <c>-ResolveOnly</c> prints without building.
+/// Building a real suite inside a test would recurse.
+/// </summary>
+public sealed class PrePushGateTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("lvai-prepush").FullName;
+
+    public void Dispose()
+    {
+        // A worktree's administrative files are read-only on Windows; clear the attribute or the
+        // recursive delete throws and every later run inherits the litter.
+        try
+        {
+            foreach (var f in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+                File.SetAttributes(f, FileAttributes.Normal);
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException) { /* best effort - %TEMP% litter is not a test failure */ }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static string? PowerShell =>
+        new[] { "pwsh.exe", "pwsh", "powershell.exe", "powershell" }
+            .Select(FindOnPath).FirstOrDefault(p => p is not null);
+
+    private static string? FindOnPath(string exe)
+    {
+        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "")
+                 .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(dir.Trim('"'), exe);
+                if (File.Exists(candidate)) return candidate;
+            }
+            catch (ArgumentException) { /* an unusable PATH entry is not ours to fix */ }
+        }
+        return null;
+    }
+
+    private static (int Code, string Output) Run(string exe, string workingDirectory, params string[] args)
+    {
+        var psi = new ProcessStartInfo(exe)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit(120_000);
+        return (p.ExitCode, stdout + stderr);
+    }
+
+    private static (int Code, string Output) Git(string workingDirectory, params string[] args)
+    {
+        var git = FindOnPath("git.exe") ?? FindOnPath("git") ?? "git";
+        return Run(git, workingDirectory, args);
+    }
+
+    /// <summary>
+    /// A throwaway repo with the REAL hook script in it, plus a linked worktree carrying its own
+    /// branch - and the ABSOLUTE <c>core.hooksPath</c> that this repository's worktrees actually
+    /// have, which is what made the main checkout's script run for a worktree's push.
+    /// </summary>
+    private (string Main, string Worktree) MakeRepoWithWorktree()
+    {
+        var main = Path.Combine(_root, "main");
+        var worktree = Path.Combine(_root, "wt");
+        Directory.CreateDirectory(Path.Combine(main, ".githooks"));
+        Directory.CreateDirectory(Path.Combine(main, "tests", "LabVIEWMCP.Tests"));
+
+        File.Copy(RepoTree.Path(".githooks", "run-tests.ps1"),
+                  Path.Combine(main, ".githooks", "run-tests.ps1"));
+        // Present in both trees, so "found the project" cannot be what distinguishes them - only
+        // WHICH tree's copy was resolved.
+        File.WriteAllText(Path.Combine(main, "tests", "LabVIEWMCP.Tests", "LabVIEWMCP.Tests.csproj"),
+                          "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        File.WriteAllText(Path.Combine(main, "CLAUDE.md"), "fixture");
+
+        Assert.Equal(0, Git(main, "init", "-q").Code);
+        Git(main, "config", "user.email", "fixture@example.invalid");
+        Git(main, "config", "user.name", "fixture");
+        Git(main, "config", "commit.gpgsign", "false");
+        Assert.Equal(0, Git(main, "add", "-A").Code);
+        Assert.Equal(0, Git(main, "commit", "-qm", "fixture").Code);
+
+        Assert.Equal(0, Git(main, "worktree", "add", "-q", worktree, "-b", "feature").Code);
+
+        // The reproduction: an absolute hooks path, in the worktree's own config, pointing at the
+        // MAIN checkout. Verbatim what `git config --show-origin --get core.hooksPath` reports in
+        // this repository's worktrees (origin: .git/worktrees/<name>/config.worktree).
+        Git(main, "config", "core.hooksPath", Path.Combine(main, ".githooks"));
+        Git(worktree, "config", "core.hooksPath", Path.Combine(main, ".githooks"));
+        return (main, worktree);
+    }
+
+    private static string ResolvedTestProject(string output)
+    {
+        var line = output.Split('\n').FirstOrDefault(l => l.Contains("test project"))
+                   ?? throw new Xunit.Sdk.XunitException(
+                       "the gate printed no 'test project' line - a wrong tree is then invisible "
+                       + "in the output, which is half of what the 2026-09-11 defect was.\n" + output);
+        return line[(line.IndexOf(':') + 1)..].Trim();
+    }
+
+    // ---------------------------------------------------------------- the tests
+
+    /// <summary>
+    /// THE REGRESSION TEST. The main checkout's script, run with a linked worktree as the working
+    /// directory - exactly how git invokes a pre-push hook there - must aim at the WORKTREE.
+    /// Against the old script this fails: it resolved the main checkout and reported PASS.
+    /// </summary>
+    [Fact]
+    public void The_gate_tests_the_worktree_being_pushed_not_the_checkout_holding_the_script()
+    {
+        if (PowerShell is null) return;   // no host: nothing to prove, nothing to fake
+        var (main, worktree) = MakeRepoWithWorktree();
+
+        var (code, output) = Run(PowerShell, workingDirectory: worktree,
+            "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", Path.Combine(main, ".githooks", "run-tests.ps1"), "-ResolveOnly");
+
+        Assert.Equal(0, code);
+        var resolved = ResolvedTestProject(output);
+
+        Assert.StartsWith(worktree, resolved, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(Path.Combine(main, "tests"), resolved, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The other half of the defect: the wrong tree was INVISIBLE. It was inferable only by
+    /// comparing test counts between the hook's output and a manual run. The resolved paths must be
+    /// in the output, so a mismatch is readable rather than detective work.
+    /// </summary>
+    [Fact]
+    public void The_gate_prints_the_tree_it_resolved_and_how()
+    {
+        if (PowerShell is null) return;
+        var (main, worktree) = MakeRepoWithWorktree();
+
+        var (_, output) = Run(PowerShell, workingDirectory: worktree,
+            "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", Path.Combine(main, ".githooks", "run-tests.ps1"), "-ResolveOnly");
+
+        Assert.Contains("tree under test", output);
+        Assert.Contains("test project", output);
+        Assert.Contains("resolved by", output);
+        Assert.Contains("rev-parse --show-toplevel", output);
+        // A linked worktree is the case that used to be silently wrong, so it is named.
+        Assert.Contains("worktree", output);
+        Assert.Contains("feature", output);
+    }
+
+    /// <summary>
+    /// The ordinary case must not regress: from a normal checkout - which is what CI pushes and
+    /// what <c>release.yml</c> runs the script in - the gate aims at that checkout, and says nothing
+    /// about a worktree.
+    /// </summary>
+    [Fact]
+    public void From_a_plain_checkout_the_gate_aims_at_that_checkout()
+    {
+        if (PowerShell is null) return;
+        var (main, _) = MakeRepoWithWorktree();
+
+        var (code, output) = Run(PowerShell, workingDirectory: main,
+            "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", Path.Combine(main, ".githooks", "run-tests.ps1"), "-ResolveOnly");
+
+        Assert.Equal(0, code);
+        Assert.StartsWith(main, ResolvedTestProject(output), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("linked (branch", output);
+    }
+
+    /// <summary>
+    /// Git's answer is authoritative, and a tree without the test project is an ERROR - never a
+    /// reason to quietly test the script's own tree instead. That silent substitution IS the
+    /// original defect, so the fallback must not be reachable while git is answering.
+    /// </summary>
+    [Fact]
+    public void A_pushed_tree_with_no_test_project_fails_rather_than_testing_another_tree()
+    {
+        if (PowerShell is null) return;
+        var (main, worktree) = MakeRepoWithWorktree();
+
+        // The worktree loses the project; the main checkout keeps it. The old script would have
+        // found main's copy and happily tested that.
+        Directory.Delete(Path.Combine(worktree, "tests"), recursive: true);
+
+        var (code, output) = Run(PowerShell, workingDirectory: worktree,
+            "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", Path.Combine(main, ".githooks", "run-tests.ps1"), "-ResolveOnly");
+
+        Assert.NotEqual(0, code);
+        Assert.Contains("test project not found", output);
+        Assert.Contains(worktree, output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Guards the shape of the fix, not just its behaviour: the primary resolution must come from
+    /// git. Re-introducing <c>Split-Path -Parent $PSScriptRoot</c> as the main route is the exact
+    /// regression, and it would pass every behavioural test above on a non-worktree machine.
+    /// </summary>
+    [Fact]
+    public void The_gate_resolves_the_tree_from_git_and_keeps_script_location_as_a_fallback_only()
+    {
+        // COMMENTS STRIPPED FIRST. The script's header quotes the old, wrong line verbatim to
+        // explain the defect, and an assertion over the whole file matches that prose instead of
+        // what runs - which is how this test failed on its first run against a correct script.
+        var code = CodeOf(RepoTree.Path(".githooks", "run-tests.ps1"));
+
+        Assert.Contains("rev-parse --show-toplevel", code);
+
+        // $PSScriptRoot may still appear - as the git-unavailable fallback - but only after git has
+        // been consulted, never as the first answer.
+        var git = code.IndexOf("rev-parse --show-toplevel", StringComparison.Ordinal);
+        var psScriptRoot = code.IndexOf("Split-Path -Parent $PSScriptRoot", StringComparison.Ordinal);
+        if (psScriptRoot >= 0)
+            Assert.True(git < psScriptRoot,
+                "the script derives the tree from its own location before asking git - that is the "
+                + "2026-09-11 worktree defect back again.");
+    }
+
+    /// <summary>The script with whole-line <c>#</c> comments removed, so assertions see only code.</summary>
+    private static string CodeOf(string path) =>
+        string.Join(Environment.NewLine,
+            File.ReadAllLines(path).Where(l => !l.TrimStart().StartsWith('#')));
+
+    /// <summary>
+    /// The SDK preflight, measured on this station the same day: <c>C:\Program Files\dotnet</c>
+    /// holds a runtime with no <c>sdk\</c> directory and comes FIRST on PATH, while the SDK
+    /// (8.0.424) lives per-user in <c>%USERPROFILE%\.dotnet</c>. A bare <c>dotnet test</c> then dies
+    /// with "No .NET SDKs were found" and a download link, and the hook aborted a push that way -
+    /// a message about installing .NET for what is purely PATH ORDER.
+    /// </summary>
+    [Fact]
+    public void The_gate_diagnoses_a_runtime_only_dotnet_rather_than_relaying_the_sdk_dump()
+    {
+        var script = File.ReadAllText(RepoTree.Path(".githooks", "run-tests.ps1"));
+
+        Assert.Contains("Find-DotnetWithSdk", script);
+        // It must judge on an sdk directory beside the host - the thing actually missing - and know
+        // the per-user install is where to look instead.
+        Assert.Contains("'sdk'", script);
+        Assert.Contains(".dotnet", script);
+        Assert.Contains("No .NET SDKs were found", script);
+    }
+}
+
+/// <summary>
+/// <see cref="RepoTree"/> - the same "which tree am I in" question, asked by the tests that assert
+/// against repository files rather than by the hook.
+///
+/// The walk it replaced looked for a DIRECTORY called <c>.git</c>. A linked worktree's <c>.git</c>
+/// is a FILE, so that probe walked past it and - because worktrees live at
+/// <c>&lt;repo&gt;\.claude\worktrees\&lt;name&gt;</c> - landed on the MAIN checkout. MEASURED
+/// 2026-09-11 from a worktree's own build output: it resolved <c>C:\Users\...\labview-mcp</c> and
+/// would have linted main's <c>scripts\</c> while the branch's went unchecked. Latent that day
+/// (the two agreed), and green either way - the same shape as the pre-push gate defect above.
+/// </summary>
+public sealed class RepoTreeTests
+{
+    /// <summary>
+    /// The decisive assertion, and the one the old walk fails. These tests were built from
+    /// <c>&lt;root&gt;\tests\LabVIEWMCP.Tests\bin\...</c>, so the resolved root must be the tree
+    /// whose <c>tests\</c> directory contains this assembly. The main checkout is an ANCESTOR of a
+    /// worktree's build output, so an ancestor check would pass for the wrong answer - containment
+    /// under <c>&lt;root&gt;\tests</c> is what separates them.
+    /// </summary>
+    [Fact]
+    public void The_resolved_root_is_the_tree_this_assembly_was_built_from()
+    {
+        var testsDir = Path.Combine(RepoTree.Root, "tests") + Path.DirectorySeparatorChar;
+        Assert.StartsWith(testsDir, AppContext.BaseDirectory, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void The_resolved_root_looks_like_this_repository()
+    {
+        Assert.True(File.Exists(Path.Combine(RepoTree.Root, "CLAUDE.md")));
+        Assert.True(Directory.Exists(Path.Combine(RepoTree.Root, "scripts")));
+        Assert.True(Directory.Exists(Path.Combine(RepoTree.Root, ".githooks")));
+    }
+
+    /// <summary>
+    /// It must not depend on <c>.git</c> at all - neither as a file nor as a directory. That is the
+    /// one signal whose TYPE changes with how the tree was created, which is what made the old walk
+    /// worktree-blind.
+    /// </summary>
+    [Fact]
+    public void Resolution_does_not_depend_on_a_git_directory()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(RepoTree.Root, "tests", "LabVIEWMCP.Tests", "Support", "RepoTree.cs"));
+        var walk = source[source.IndexOf("private static string FindRoot", StringComparison.Ordinal)..];
+        Assert.DoesNotContain("Directory.Exists(System.IO.Path.Combine(directory, \".git\")", walk);
+    }
+
+    [Fact]
+    public void Path_composes_under_the_resolved_root() =>
+        Assert.Equal(Path.Combine(RepoTree.Root, "scripts", "templates"),
+                     RepoTree.Path("scripts", "templates"));
+}
+
+/// <summary>
+/// The third instance of the same worktree-blindness, found by the noise it made rather than by a
+/// failure: <c>Directory.Build.targets</c>' hook-activation guard tested <c>Exists('.git')</c>, and
+/// MSBuild's <c>Exists</c> is true for a FILE - which is what a linked worktree's <c>.git</c> is.
+/// So the target fired on every build in a worktree, could not create its marker inside a path
+/// whose <c>.git</c> is not a directory, and emitted three MSB3371 warnings per build for ever.
+/// MEASURED 2026-09-11 on a worktree build, before the condition moved to <c>.git\config</c>.
+/// </summary>
+public sealed class GitHookActivationTargetTests
+{
+    private static string Targets => File.ReadAllText(RepoTree.Path("Directory.Build.targets"));
+
+    /// <summary>
+    /// The file with every <c>&lt;!-- --&gt;</c> block removed. The rationale comment quotes the old,
+    /// wrong condition verbatim, so asserting over the raw text matches the explanation instead of
+    /// the live Target - which is exactly how this test failed on its first run against a correct
+    /// file.
+    /// </summary>
+    private static string Markup =>
+        System.Text.RegularExpressions.Regex.Replace(
+            Targets, "<!--.*?-->", "", System.Text.RegularExpressions.RegexOptions.Singleline);
+
+    /// <summary>
+    /// The guard must key on something that exists ONLY where <c>.git</c> is a real directory.
+    /// <c>Exists('....git')</c> alone is the defect, because it is satisfied by a worktree's
+    /// <c>.git</c> file and then nothing downstream can work.
+    /// </summary>
+    [Fact]
+    public void The_guard_distinguishes_a_checkout_from_a_linked_worktree()
+    {
+        Assert.Contains(@"Exists('$(MSBuildThisFileDirectory).git\config')", Markup);
+        Assert.DoesNotContain(@"Exists('$(MSBuildThisFileDirectory).git')", Markup);
+    }
+
+    /// <summary>
+    /// And the discriminator has to be true of this machine, not just of the docs: a linked
+    /// worktree has no <c>.git\config</c>, a normal checkout does. Asserted from whichever kind of
+    /// tree the tests are running in, so both shapes are covered across a worktree and CI.
+    /// </summary>
+    [Fact]
+    public void A_worktree_has_no_git_config_beside_it_while_a_checkout_does()
+    {
+        var dotGit = Path.Combine(RepoTree.Root, ".git");
+        if (File.Exists(dotGit))            // a linked worktree: .git is a gitdir: pointer file
+        {
+            Assert.False(File.Exists(Path.Combine(dotGit, "config")));
+            Assert.StartsWith("gitdir:", File.ReadAllText(dotGit).TrimStart());
+        }
+        else if (Directory.Exists(dotGit))  // a normal checkout (CI, a plain clone)
+        {
+            Assert.True(File.Exists(Path.Combine(dotGit, "config")));
+        }
+        // Neither: an exported tree with no git metadata. Nothing to assert.
+    }
+
+    /// <summary>
+    /// The value written must stay RELATIVE. An absolute one would be inherited by every linked
+    /// worktree and point them all at the main checkout's hooks - which is how the pre-push gate
+    /// came to run the wrong tree's script in the first place. (The absolute value observed on this
+    /// station comes from the worktree tooling's own config.worktree, not from here; this keeps it
+    /// that way.)
+    /// </summary>
+    [Fact]
+    public void The_configured_hooks_path_is_relative()
+    {
+        Assert.Contains("git config core.hooksPath .githooks", Markup);
+        Assert.DoesNotContain("git config core.hooksPath \"$(MSBuildThisFileDirectory)", Markup);
+    }
+}

--- a/tests/LabVIEWMCP.Tests/Infra/PrePushGateTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/PrePushGateTests.cs
@@ -229,6 +229,84 @@ public sealed class PrePushGateTests : IDisposable
     }
 
     /// <summary>
+    /// THE FALLBACK MUST NOT REOPEN THE DEFECT. Found the hard way while verifying this very fix:
+    /// with <c>core.bare</c> accidentally true on the shared config, <c>rev-parse
+    /// --show-toplevel</c> answers "fatal: this operation must be run in a work tree" - and the
+    /// first version of the fixed script fell back to its own location, tested the MAIN checkout
+    /// and printed PASS for a worktree's push. The original defect, back through the escape hatch.
+    ///
+    /// So when git is driving (<c>GIT_DIR</c> is exported to a hook - measured) and git cannot name
+    /// the work tree, the gate must refuse rather than guess. The fixture reproduces the real
+    /// broken state, not a mocked one: <c>core.bare = true</c> on a repo that has a work tree.
+    /// </summary>
+    [Fact]
+    public void As_a_hook_it_refuses_to_guess_when_git_cannot_name_the_work_tree()
+    {
+        if (PowerShell is null) return;
+        var (main, worktree) = MakeRepoWithWorktree();   // worktree is the hook's cwd
+
+        // Reproduce the CONDITION rather than one cause of it: git driving, and no work tree it
+        // can name. A bare repository as GIT_DIR does that every time - `rev-parse
+        // --show-toplevel` answers "fatal: this operation must be run in a work tree", the same
+        // refusal the real accident produced. (Setting core.bare on the fixture was tried first
+        // and does NOT reproduce it: measured, a linked worktree still resolves fine that way, so
+        // the test would have passed without exercising the branch at all.)
+        var bare = Path.Combine(_root, "bare.git");
+        Assert.Equal(0, Git(_root, "init", "-q", "--bare", bare).Code);
+
+        var psi = new ProcessStartInfo(PowerShell)
+        {
+            WorkingDirectory = worktree,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var a in new[] { "-NoProfile", "-ExecutionPolicy", "Bypass",
+                                  "-File", Path.Combine(main, ".githooks", "run-tests.ps1") })
+            psi.ArgumentList.Add(a);
+        // What git itself exports to a hook, which is how the script knows it is one.
+        psi.Environment["GIT_DIR"] = bare;
+
+        using var p = Process.Start(psi)!;
+        var output = p.StandardOutput.ReadToEnd() + p.StandardError.ReadToEnd();
+        p.WaitForExit(120_000);
+
+        Assert.NotEqual(0, p.ExitCode);
+        Assert.Contains("could not name the work tree", output);
+        // And it must not have reached a test run, let alone reported one.
+        Assert.DoesNotContain("PASS:", output);
+    }
+
+    /// <summary>
+    /// Run BY HAND outside a work tree - an exported zip, a CI checkout with no git metadata - the
+    /// script's own location is the best evidence there is and the fallback is legitimate, because
+    /// no push is in flight. It must say so rather than implying git answered.
+    /// </summary>
+    [Fact]
+    public void Run_by_hand_outside_a_work_tree_it_falls_back_and_says_so()
+    {
+        if (PowerShell is null) return;
+        var (main, _) = MakeRepoWithWorktree();
+
+        // A copy of the tree with no git metadata at all.
+        var exported = Path.Combine(_root, "exported");
+        Directory.CreateDirectory(Path.Combine(exported, ".githooks"));
+        Directory.CreateDirectory(Path.Combine(exported, "tests", "LabVIEWMCP.Tests"));
+        File.Copy(Path.Combine(main, ".githooks", "run-tests.ps1"),
+                  Path.Combine(exported, ".githooks", "run-tests.ps1"));
+        File.WriteAllText(
+            Path.Combine(exported, "tests", "LabVIEWMCP.Tests", "LabVIEWMCP.Tests.csproj"), "<Project/>");
+
+        var (code, output) = Run(PowerShell, workingDirectory: exported,
+            "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", Path.Combine(exported, ".githooks", "run-tests.ps1"), "-ResolveOnly");
+
+        Assert.Equal(0, code);
+        Assert.Contains("script location", output);
+        Assert.StartsWith(exported, ResolvedTestProject(output), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Guards the shape of the fix, not just its behaviour: the primary resolution must come from
     /// git. Re-introducing <c>Split-Path -Parent $PSScriptRoot</c> as the main route is the exact
     /// regression, and it would pass every behavioural test above on a non-worktree machine.

--- a/tests/LabVIEWMCP.Tests/Infra/PrePushGateTests.cs
+++ b/tests/LabVIEWMCP.Tests/Infra/PrePushGateTests.cs
@@ -66,7 +66,27 @@ public sealed class PrePushGateTests : IDisposable
         return null;
     }
 
-    private static (int Code, string Output) Run(string exe, string workingDirectory, params string[] args)
+    private static (int Code, string Output) Run(string exe, string workingDirectory, params string[] args) =>
+        Run(exe, workingDirectory, null, args);
+
+    /// <summary>
+    /// Runs a child process with EVERY <c>GIT_*</c> VARIABLE STRIPPED, then applies
+    /// <paramref name="env"/>.
+    ///
+    /// THIS IS NOT HYGIENE, IT IS THE DIFFERENCE BETWEEN THESE TESTS WORKING AND ABORTING EVERY
+    /// PUSH. Git exports <c>GIT_DIR</c> - and, during a push, <c>GIT_INDEX_FILE</c>,
+    /// <c>GIT_PREFIX</c>, <c>GIT_QUARANTINE_PATH</c> and friends - into a hook's environment, and a
+    /// child inherits them. So when these tests run from inside the pre-push gate, the fixture's
+    /// own `git init` / `git add` / `git commit` were aimed at THE REAL REPOSITORY and failed with
+    /// exit 128, and the script under test resolved the real worktree instead of the fixture.
+    ///
+    /// MEASURED 2026-09-11 by the first real push through the fixed hook: 6 of these tests failed
+    /// inside the hook while all 1640 passed under a plain `dotnet test`. Nothing but running them
+    /// in their actual environment would have shown it - and left unfixed, the gate they verify
+    /// would have blocked every worktree push.
+    /// </summary>
+    private static (int Code, string Output) Run(
+        string exe, string workingDirectory, IDictionary<string, string>? env, params string[] args)
     {
         var psi = new ProcessStartInfo(exe)
         {
@@ -76,6 +96,14 @@ public sealed class PrePushGateTests : IDisposable
             UseShellExecute = false,
         };
         foreach (var a in args) psi.ArgumentList.Add(a);
+
+        foreach (var key in psi.Environment.Keys
+                     .Where(k => k.StartsWith("GIT_", StringComparison.OrdinalIgnoreCase))
+                     .ToList())
+            psi.Environment.Remove(key);
+
+        if (env is not null)
+            foreach (var (k, v) in env) psi.Environment[k] = v;
 
         using var p = Process.Start(psi)!;
         var stdout = p.StandardOutput.ReadToEnd();
@@ -254,24 +282,13 @@ public sealed class PrePushGateTests : IDisposable
         var bare = Path.Combine(_root, "bare.git");
         Assert.Equal(0, Git(_root, "init", "-q", "--bare", bare).Code);
 
-        var psi = new ProcessStartInfo(PowerShell)
-        {
-            WorkingDirectory = worktree,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        foreach (var a in new[] { "-NoProfile", "-ExecutionPolicy", "Bypass",
-                                  "-File", Path.Combine(main, ".githooks", "run-tests.ps1") })
-            psi.ArgumentList.Add(a);
-        // What git itself exports to a hook, which is how the script knows it is one.
-        psi.Environment["GIT_DIR"] = bare;
+        // GIT_DIR is what git itself exports to a hook, and is how the script knows it is one.
+        var (code, output) = Run(PowerShell, workingDirectory: worktree,
+            new Dictionary<string, string> { ["GIT_DIR"] = bare },
+            "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", Path.Combine(main, ".githooks", "run-tests.ps1"));
 
-        using var p = Process.Start(psi)!;
-        var output = p.StandardOutput.ReadToEnd() + p.StandardError.ReadToEnd();
-        p.WaitForExit(120_000);
-
-        Assert.NotEqual(0, p.ExitCode);
+        Assert.NotEqual(0, code);
         Assert.Contains("could not name the work tree", output);
         // And it must not have reached a test run, let alone reported one.
         Assert.DoesNotContain("PASS:", output);

--- a/tests/LabVIEWMCP.Tests/Support/RepoTree.cs
+++ b/tests/LabVIEWMCP.Tests/Support/RepoTree.cs
@@ -1,0 +1,55 @@
+namespace LabVIEWMcp.Tests.Support;
+
+/// <summary>
+/// Locates the working tree the running tests were BUILT FROM, for the handful of tests that
+/// assert against repository files (the shipped <c>scripts\</c> helpers, the agent definitions).
+///
+/// WHY THIS IS NOT A ONE-LINER. The obvious walk - climb from
+/// <see cref="AppContext.BaseDirectory"/> until a directory has a <c>.git</c> - is WRONG in a
+/// linked worktree, and wrong in the direction that produces a green test about somebody else's
+/// code. A linked worktree's <c>.git</c> is a FILE holding a <c>gitdir:</c> pointer, not a
+/// directory, so a <c>Directory.Exists</c> probe walks straight past it. This repository keeps its
+/// worktrees at <c>&lt;repo&gt;\.claude\worktrees\&lt;name&gt;</c>, so the next <c>.git</c> the walk
+/// meets is a real directory: the MAIN checkout's.
+///
+/// MEASURED 2026-09-11, replicating the old walk from a worktree's test output directory: it landed
+/// on <c>C:\Users\...\labview-mcp</c> and would have linted main's <c>scripts\</c> while the branch
+/// under test went unchecked. The two trees' helpers happened to agree that day, so nothing failed
+/// and nothing reported it - exactly the shape of the pre-push gate defect fixed in the same pass
+/// (see <c>.githooks\run-tests.ps1</c>, "the worktree trap"), where the hook tested main and printed
+/// PASS for a branch it had never built.
+///
+/// So match on the repository's own CONTENT instead of on <c>.git</c>. <c>CLAUDE.md</c> beside a
+/// <c>scripts\</c> directory identifies this repo and is present in a worktree, a normal clone and
+/// a CI checkout alike - and, unlike <c>.git</c>, is not a different kind of filesystem object
+/// depending on how the tree was created.
+/// </summary>
+internal static class RepoTree
+{
+    /// <summary>The root of the working tree these tests were built from.</summary>
+    internal static string Root { get; } = FindRoot();
+
+    /// <summary>A path inside that tree, e.g. <c>RepoTree.Path("scripts")</c>.</summary>
+    internal static string Path(params string[] parts) =>
+        System.IO.Path.Combine(new[] { Root }.Concat(parts).ToArray());
+
+    private static string FindRoot()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(directory))
+        {
+            if (Directory.Exists(System.IO.Path.Combine(directory, "scripts"))
+                && File.Exists(System.IO.Path.Combine(directory, "CLAUDE.md")))
+                return directory;
+
+            var parent = System.IO.Path.GetDirectoryName(directory);
+            if (parent == directory) break;   // reached a filesystem root
+            directory = parent;
+        }
+
+        // No marker anywhere above us. Returning the build output is the least surprising
+        // answer: the caller's own Test-Path/File.Exists then fails, naming a path, instead of
+        // this silently substituting a different tree.
+        return AppContext.BaseDirectory;
+    }
+}

--- a/tests/LabVIEWMCP.Tests/Tools/WireEventToolsTests.cs
+++ b/tests/LabVIEWMCP.Tests/Tools/WireEventToolsTests.cs
@@ -1,4 +1,5 @@
 using LabVIEWMcp.Tools;
+using LabVIEWMcp.Tests.Support;
 using Xunit;
 
 namespace LabVIEWMcp.Tests.Tools;
@@ -268,15 +269,7 @@ public sealed class WireEventToolsTests
         Assert.Contains("value=\"diagram\"", text);
     }
 
-    private static string RepoRoot()
-    {
-        var directory = AppContext.BaseDirectory;
-        while (directory is { Length: > 0 })
-        {
-            if (Directory.Exists(Path.Combine(directory, "scripts"))
-                && File.Exists(Path.Combine(directory, "CLAUDE.md"))) return directory;
-            directory = Path.GetDirectoryName(directory) ?? string.Empty;
-        }
-        return AppContext.BaseDirectory;
-    }
+    // This walk was already worktree-correct; it now shares one implementation with the rest,
+    // so there is a single place to fix and a single place tested. See RepoTree.
+    private static string RepoRoot() => RepoTree.Root;
 }


### PR DESCRIPTION
## The defect

The pre-push gate silently tested the **wrong working tree** when pushing from a git worktree, and reported PASS without having run the branch's tests.

`run-tests.ps1` derived the tree under test from its own location (`Split-Path -Parent $PSScriptRoot`). But `core.hooksPath` is git *config*, and config is shared between a repository and every linked worktree — stored here as an **absolute** path in `.git/worktrees/<name>/config.worktree`. So a push from `.claude/worktrees/<name>` ran the **main checkout's** script, and the gate tested whatever was checked out at `main`.

Measured 2026-09-11: the hook printed `Failed: 0, Passed: 1625` while the same script run by hand inside the worktree printed `1667`. The 42 difference was exactly the two test files that branch added. **A green gate for an unrelated tree is worse than no gate**, and the only tell was a test count nobody compares.

> The push that created this PR demonstrated it once more: the old hook reported `Passed: 1667` from `labview-mcp\tests\...` — the main checkout — while this branch has 1640.

## The fix

`.githooks/run-tests.ps1` resolves the tree with `git rev-parse --show-toplevel`. Measured with a probe hook in a real linked worktree: cwd, `--show-toplevel` and `--git-dir` all name the worktree, and the exported `GIT_DIR` (`<main>/.git/worktrees/<name>`) does not misdirect it.

It now prints the aim before doing anything, so a wrong tree is visible rather than inferable from a count:

```
  tree under test : ...\.claude\worktrees\my-branch
  test project    : ...\my-branch\tests\LabVIEWMCP.Tests\LabVIEWMCP.Tests.csproj
  resolved by     : git rev-parse --show-toplevel
  worktree        : linked (branch claude/my-branch)
```

There is deliberately **no silent fallback** while git is answering — a resolved tree with no test project is an error it stops on, because falling back is the behaviour being replaced. `-ResolveOnly` prints the aim without building.

## The same question, asked wrong in two more places

Both fixed here. In each case the signal was a **green** result about someone else's code:

| Where | What it did | Why |
|---|---|---|
| `AixmlCheckTests.RepoRoot` | linted **main's** `scripts\` instead of the branch's | walked for a *directory* called `.git`; a worktree's `.git` is a **file**, so the walk went past it to the main checkout above |
| `Directory.Build.targets` | re-ran its one-time hook setup on **every** worktree build, warning `MSB3371` three times | MSBuild's `Exists()` is true for a file, so `Exists('.git')` fired in a worktree where the marker can never be written |

`tests/LabVIEWMCP.Tests/Support/RepoTree.cs` is now the single resolver for the test side, matching `CLAUDE.md` beside `scripts\` — repository content, identical in a worktree, a clone and a CI checkout — rather than `.git`, whose *kind* of filesystem object depends on how the tree was created.

**On the `core.hooksPath` question:** `Directory.Build.targets` already wrote the **relative** `.githooks`, into `.git/config`. The absolute value comes from the worktree tooling's `config.worktree`, which *shadows* it. Nothing to change there; the target now simply skips in worktrees, which is also correct since the hooks path is shared config the main checkout has already set.

## The .NET SDK preflight

`C:\Program Files\dotnet` holds a runtime with **no `sdk` directory** and comes first on `PATH`, while the SDK (8.0.424) is per-user in `%USERPROFILE%\.dotnet`. A bare `dotnet test` therefore dies with `No .NET SDKs were found` and a download link — for what is purely **PATH order**, and it aborted a push that way.

The gate now finds a `dotnet` with an `sdk\` directory beside it (checking `DOTNET_ROOT`, `%USERPROFILE%\.dotnet`, all of `PATH`), uses that one for its own process and says which; otherwise it prints the diagnosis and the two commands that confirm it, instead of relaying the raw dump.

> This goes slightly beyond the "clearer message" that was asked for — it repairs rather than only reports. Flagging it as a reviewable choice; it is a two-line revert if the gate should leave `PATH` alone.

## Two things only a real push found

A plain `dotnet test` was green throughout both of these.

1. **A hook's children inherit `GIT_*`, and the gate's own tests corrupted the repo.** Git exports `GIT_DIR` to every hook, plus `GIT_INDEX_FILE` / `GIT_PREFIX` / `GIT_QUARANTINE_PATH` during a push, and a child `git` obeys those over its own working directory. So `PrePushGateTests`' fixture-building `git init` ran against the repository being pushed — and with `GIT_DIR` set and no work tree, `git init` marks it **bare**. `core.bare = true` on the real repo; every later work-tree operation answered `fatal: this operation must be run in a work tree`. Repaired (`git config core.bare false`, `git fsck` clean). `PrePushGateTests.Run` now strips every `GIT_*`; **any future test that shells out to `git` must do the same.** Left unfixed this would have blocked every worktree push.

2. **The first version of the fix had the defect's own escape hatch.** While that config was broken, the *fixed* script fell back to its own location, tested `main` and printed **PASS**. `GIT_DIR` being set is now how the script knows it is a hook, and as a hook git's answer is mandatory.

## Verification

- `PrePushGateTests` builds a real `git worktree add` fixture carrying the absolute `core.hooksPath` and drives the real script through it — a fixture that merely *looked* like a worktree passed against the broken script too.
- **Each fix reverted in turn to confirm its tests fail without it:** 7 of 13 fail against the pre-fix hook script and targets, 2 against the old repo-root walk, 1 against the un-hardened fallback.
- **End to end:** a real push from a worktree through the real hook resolved the worktree, built the worktree's assembly and reported **1640 of 1640** — matching that worktree's own `dotnet test` exactly, where the unfixed hook reported 1625 for the main checkout.
- The CI invocation path (`powershell -File .githooks/run-tests.ps1`, no `GIT_DIR`, SDK already first on `PATH` as `actions/setup-dotnet` arranges): exit 0, correct tree, preflight correctly silent and `PATH` untouched.
- `MSB3371` gone; `build.ps1` reports `CLAUDE.md embedded verbatim`; full suite 1640/1640.

**Not verified:** the real GitHub Actions runner. The 8 new process-spawning tests were simulated locally but have not run on `windows-latest`. They also no-op if no PowerShell host is found — harmless on Windows, but a weaker guarantee than a failure; happy to make them fail loudly on Windows and skip only elsewhere.

Measurements are recorded in `CLAUDE.md`'s "Build and test" section and `.githooks/README.md`.

### A third consequence of the same leak: the repo's IDENTITY

`core.bare` was the loud half. The fixture also ran `git config user.email` / `user.name` /
`commit.gpgsign`, so the real `.git/config` gained a `[user]` section reading
`fixture <fixture@example.invalid>` and a `[commit] gpgsign = false` - **neither section existed
before** - and two commits on this branch were authored by `fixture`. Nothing warns: the repo-local
identity simply wins over the global one.

**The repair was to UNSET the local keys, not to set a value.** The identity had always come from
`~/.gitconfig`, so writing a guessed name would have pinned the repo to it for ever. The commits
were re-authored with `git rebase <base> --exec "git commit --amend --no-edit --reset-author"`.

So one inherited `GIT_DIR` produced three distinct kinds of damage - a bare repo, a wrong author,
and silently disabled commit signing - and only the first announced itself. The general rule, now
recorded: **when a stray process has written to a repo's config, diff the whole file against what it
should contain rather than fixing the symptom you noticed.**

## Rebased and merged onto current `main`

`main` moved twice during this work. Both are merged in and the combined suite is green at
**1693/1693** (my 13 new tests, plus the 11 from #52).

Checked for functional clash, and there is none:

- **#51** (release tags / install versioning) touched none of my files.
- **#52** (reject a hand-cut release, stage README.md) overlaps only in `CLAUDE.md`, and merged
  without conflict. `release.yml` still invokes the gate identically (the step moved from line 41 to
  68), which is the path verified above; the new `verify-release.yml` does not run the gate at all.
- `build.ps1` and `scripts/Assert-PublishedRelease.ps1` do use `$MyInvocation.MyCommand.Path` /
  `$PSScriptRoot`, which looks like the pattern fixed here but is the **correct** form of it: they
  locate their own tree, or a sibling script, rather than a tree git chose. Deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
