### PR TITLE
Drop the release trigger from verify-release: it raced the publish

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -20,13 +20,28 @@ name: verify-release
 #
 # The daily schedule is the part that matters. An asset can be replaced on an existing release at
 # any time, long after any workflow ran, so the only reliable guard is to keep looking.
+#
+# THERE IS DELIBERATELY NO `release:` TRIGGER, and it was tried first. Measured 2026-09-11 over
+# v1.5.0 and v1.5.1: every automatically triggered run failed - 5 of 5 - and the one green run in
+# that history was a manual re-run. Two independent reasons, each fatal:
+#
+#   - A release in this repository is created in the GitHub UI, which creates the tag, which
+#     triggers release.yml by push. So the release EXISTS WITH ZERO ASSETS about two seconds
+#     before the publishing workflow even starts, and release.yml then takes 3-5 minutes to
+#     attach them. No retry window inside a release event can close that gap honestly, and the
+#     failure text - "the release has no asset named labview-mcp.zip" - is alarming and wrong.
+#   - It was also redundant. `release.yml`'s own final step re-downloads what it just published
+#     and runs THIS SAME script against it, after the attach step, which is the correct moment.
+#     Verified green on both v1.5.0 and v1.5.1.
+#
+# A third, smaller reason not to bring it back: one publish fires `created`, `published` AND
+# `released`, so five event types produced three concurrent racing runs per release.
+#
+# What the schedule still covers is exactly what release.yml structurally cannot: a release CI
+# never published. All five hand-cut releases had no release.yml run at all, so there was no
+# final step to catch them - which is the whole reason this file exists.
 
 on:
-  release:
-    # `published` covers a release created as published or promoted from draft; `edited` and
-    # `released` cover a later change to an existing one - which is exactly how an asset gets
-    # swapped after the fact.
-    types: [published, edited, released, created, prereleased]
   schedule:
     # Daily. Not on the hour, so it is not queued behind everyone else's cron.
     - cron: '17 6 * * *'
@@ -50,24 +65,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # The tag to check, by trigger:
-      #   release event      -> the release that fired it
-      #   workflow_dispatch  -> the input, if given
-      #   schedule           -> blank, so the script checks /releases/latest, which is what the
-      #                         marketplace resolves and therefore what every install receives
+      # The tag to check:
+      #   workflow_dispatch -> the input, when one is given
+      #   schedule          -> blank, so the script checks /releases/latest, which is what the
+      #                        marketplace resolves and therefore what every install receives
       - name: Decide which release to check
         id: which
         shell: pwsh
         run: |
-          $tag = '${{ github.event.release.tag_name }}'
-          if (-not $tag) { $tag = '${{ inputs.tag }}' }
+          $tag = '${{ inputs.tag }}'
           if ($tag) { Write-Host "checking tag $tag" } else { Write-Host 'checking /releases/latest' }
           "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      # Retried, because a release event can fire while the 63 MB assets are still uploading - the
-      # asset set would then be incomplete through no fault of the publisher. Three attempts a
-      # minute apart; a hand-cut release still fails all three, and this costs nothing when the
-      # first one passes.
+      # Retried only to absorb a transient - an API hiccup, or a dispatch aimed at a release whose
+      # upload is genuinely in flight. It is NOT here to wait out a publishing run: that race is
+      # why the release trigger was removed, because 60 s three times cannot cover the 3-5 minutes
+      # release.yml takes to attach its assets.
       - name: Verify the published release
         shell: pwsh
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1613,9 +1613,20 @@ not start without the .NET 8 runtime, and a pylabview bundle off a workstation's
 the version `release.yml` pins away from because it emits SyntaxWarnings from `LVheap.py` on every
 import. For four days `/releases/latest/download/labview-mcp.zip` served one of those to every
 plugin install, which is what the README's "problem with the installer" banner was describing.
-`scripts/Assert-PublishedRelease.ps1` rejects one now, run per release event and **daily** by
-`.github/workflows/verify-release.yml` — daily because an asset can be swapped long after any
-workflow ran.
+`scripts/Assert-PublishedRelease.ps1` rejects one now, run as `release.yml`'s **last step** against
+the release it just cut, and **daily** by `.github/workflows/verify-release.yml` — daily because an
+asset can be swapped long after any workflow ran, and because the five hand-cut releases had no
+`release.yml` run at all, so no final step could have caught them.
+
+**DO NOT ADD A `release:` TRIGGER TO THAT WORKFLOW — it was there, and it failed 5 of 5.** Measured
+2026-09-11 over v1.5.0 and v1.5.1: a release here is created in the GitHub UI, which creates the tag,
+which starts `release.yml` by push — so the release exists **with zero assets** about two seconds
+before the publishing run begins and 3-5 minutes before it attaches anything, and `3 x 60 s` of
+retrying cannot cover that. It was also redundant, because `release.yml`'s own final step was green
+on both releases while the event-triggered runs failed beside it; and one publish fires `created`,
+`published` *and* `released`, so five event types produced three concurrent racing runs per release.
+**A guard placed on an event that fires before the thing it checks exists measures the clock, not
+the artefact.**
 
 **The process lesson generalises past releases: A PIPELINE GUARANTEE IS NOT A PROPERTY OF THE
 ARTEFACT.** "There is one build and one packaging path" was true of the workflow and said nothing

--- a/README.md
+++ b/README.md
@@ -1031,9 +1031,14 @@ off a workstation's **Python 3.14** (the version the workflow pins away from, be
 SyntaxWarnings from `LVheap.py` on every import). For four days
 `/releases/latest/download/labview-mcp.zip` served it to every plugin install.
 
-[`.github/workflows/verify-release.yml`](.github/workflows/verify-release.yml) now rejects one — on
-every release event and on a **daily schedule**, because an asset can be replaced on an existing
-release long after any workflow has finished. Run the same check yourself at any time:
+Two things reject one now, and they cover different failures. `release.yml`'s **final step**
+re-downloads the release it has just cut and verifies it — that is the only moment a freshly
+published release is complete. And [`.github/workflows/verify-release.yml`](.github/workflows/verify-release.yml)
+runs the same check **daily**, which covers what `release.yml` cannot see: a release CI never
+published at all, or an asset replaced on an existing release afterwards. (There is deliberately no
+`release:` trigger — a release here exists with zero assets seconds before the publishing workflow
+starts, so every event-triggered run raced it and failed. The header of that file has the
+measurement.) Run the same check yourself at any time:
 
 ```bash
 powershell -ExecutionPolicy Bypass -File scripts/Assert-PublishedRelease.ps1

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -113,10 +113,31 @@ anything.
 
 ## 2b. What now rejects a hand-cut release
 
-`scripts/Assert-PublishedRelease.ps1`, run by `.github/workflows/verify-release.yml` on every
-release event and on a **daily schedule**, and as the last step of `release.yml` against the
-release it has just cut. The daily run is the part that matters: an asset can be replaced on an
-existing release at any time, long after any workflow has finished.
+`scripts/Assert-PublishedRelease.ps1`, run in two places that cover different things:
+
+- as the **last step of `release.yml`**, against the release it has just cut. That step runs after
+  its own attach step, which is the only moment at which a freshly published release is complete.
+- **daily**, by `.github/workflows/verify-release.yml`. This covers what `release.yml` structurally
+  cannot — a release CI never published at all (all five hand-cut ones had no `release.yml` run, so
+  there was no final step to catch them), or an asset replaced on an existing release afterwards.
+
+**There is deliberately no `release:` trigger, and that was learned the hard way the same day.**
+The first version of `verify-release.yml` fired on five release event types, and measured over
+v1.5.0 and v1.5.1 **every automatically triggered run failed — 5 of 5**; the one green run in that
+history was a manual re-run. Two independent causes:
+
+| | |
+|---|---|
+| **the race is structural** | A release here is created in the GitHub UI, which creates the tag, which starts `release.yml` by push. So the release exists **with zero assets** about two seconds before the publishing run begins, and 3–5 minutes before it attaches anything. No retry window inside a release event closes that honestly, and the failure text — *"the release has no asset named labview-mcp.zip"* — is alarming and wrong. |
+| **it was redundant** | `release.yml`'s own final step already runs this script against the finished release, and was green on both v1.5.0 and v1.5.1 while the event-triggered runs were failing beside it. |
+
+A third, smaller reason not to bring it back: one publish fires `created`, `published` *and*
+`released`, so five event types produced **three concurrent racing runs per release**.
+
+The lesson is narrower than the earlier ones on this page but worth keeping: **a guard placed on an
+event that fires before the thing it checks exists does not measure the artefact, it measures the
+clock.** The correct trigger for "is the published release complete" is the step that publishes it;
+the correct trigger for "has it been tampered with since" is a schedule.
 
 It downloads what is published and checks, in this order:
 

--- a/scripts/Assert-PublishedRelease.ps1
+++ b/scripts/Assert-PublishedRelease.ps1
@@ -30,8 +30,19 @@
     ignored, which is what left no CI asset to publish). It does NOT stop anyone uploading an asset
     by hand, and this does: it reads what is published and fails loudly.
 
-    Run by .github\workflows\verify-release.yml on every release event and on a daily schedule, and
-    as the last step of release.yml against the release it has just cut.
+    Run as the last step of release.yml against the release it has just cut, and DAILY by
+    .github\workflows\verify-release.yml.
+
+    Those two cover different things, and it is worth not confusing them. release.yml's step runs
+    after its own attach step, which is the only moment at which a freshly published release is
+    complete. The daily run covers what release.yml structurally cannot: a release CI never
+    published at all, or an asset replaced on an existing release afterwards.
+
+    There is deliberately no `release:` trigger. It was tried and removed the same day - measured
+    over v1.5.0 and v1.5.1, all five automatically triggered runs failed, because a release here is
+    created in the GitHub UI (which creates the tag, which starts release.yml by push), so the
+    release exists with ZERO assets seconds before the publishing run begins and minutes before it
+    attaches anything. See the header of verify-release.yml.
 
 .PARAMETER Repo
     owner/name to query. Default: this repository.


### PR DESCRIPTION
## TL;DR

`verify-release.yml`'s `release:` trigger was wrong and is removed. **Every automatically triggered run failed — 5 of 5** across v1.5.0 and v1.5.1; the one green run in that history was a manual re-run.

The workflow itself is **kept**, because the failing trigger and the valuable trigger are different triggers in the same file.

## Why the trigger could never work

**The race is structural.** A release in this repository is created in the GitHub UI, which creates the tag, which starts `release.yml` by push. Measured on v1.5.0:

| | |
|---|---|
| release published | `22:00:20Z`, **0 assets** |
| `release.yml` starts (push event) | `22:00:22Z` |
| three `verify-release` runs fire | `22:00:22Z` — all racing |
| `release.yml` attaches the assets | ~`22:05:16Z` |

So the release exists with zero assets two seconds *before* the publishing run begins and 3–5 minutes before it attaches anything. The job's `3 × 60 s` of retrying cannot cover that, and what it reported is alarming and wrong:

```
FAIL  the release has no asset named 'labview-mcp.zip'. The marketplace resolves
      /releases/latest/download/labview-mcp.zip, so nothing can install this release.
```

**It was also redundant.** `release.yml`'s own final step re-downloads what it just published and runs the same script against it, *after* the attach step — the only moment a freshly published release is complete. That step was **green on both v1.5.0 and v1.5.1** while the event-triggered runs were failing beside them.

**And it fanned out.** One publish fires `created`, `published` *and* `released`, so five event types produced **three concurrent racing runs per release**.

## Why the file stays

The daily schedule covers exactly what `release.yml` structurally cannot:

- a release CI **never published at all** — all five hand-cut releases (`V1.1.5`, `V1.2.0`, `V1.2.2`, `V1.2.5`, `V1.2.8`) had no `release.yml` run, so there was no final step that could have caught them. That is the whole reason the file exists.
- an asset **replaced on an existing release** afterwards, long after any workflow finished.

Deleting the workflow would have removed the only guard against the original incident while leaving the redundant part in place.

## Changes

- `.github/workflows/verify-release.yml` — `on:` is now `schedule` + `workflow_dispatch`. The tag-selection step no longer reads `github.event.release.tag_name`, and the retry loop is re-justified (it absorbs a transient; it is explicitly *not* there to wait out a publishing run).
- The header records the measurement, so the trigger does not get added back.
- `CLAUDE.md`, `README.md`, `docs/release-versioning.md` and the script's own synopsis all said *"on every release event and on a daily schedule"*. All four corrected, each stating what it used to claim and why it was wrong.

## The lesson, recorded in `docs/release-versioning.md` §2b

**A guard placed on an event that fires before the thing it checks exists measures the clock, not the artefact.** The correct trigger for *"is the published release complete"* is the step that publishes it; the correct trigger for *"has it been tampered with since"* is a schedule.

## Verification

- Both workflow YAMLs parsed; `verify-release` triggers confirmed as `['schedule', 'workflow_dispatch']`; all 20 embedded `pwsh` blocks syntax-checked with PowerShell's own parser.
- Full suite **1693 passed, 0 failed**; `build.ps1` clean with all embedded documents byte-identical.
- No behaviour change to `Assert-PublishedRelease.ps1` itself — only its synopsis.

The five failed runs already in the Actions history are false alarms from the old trigger and can be ignored or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
